### PR TITLE
docs/setup: clean up install docs, add CI, and lock projection regression coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# Clinical Trial Matching environment examples
+#
+# Root/backend usage:
+#   cp .env.example .env
+#
+# Frontend usage:
+#   copy the frontend section below into frontend/.env.local
+
+# -----------------------------------------------------------------------------
+# Root / backend / docker-compose environment
+# -----------------------------------------------------------------------------
+
+# Database
+CTM_DATABASE_URL=postgresql://ctm:***@localhost:5432/clinical_trials
+
+# API authentication
+CTM_API_KEY=local-dev-api-key
+
+# ClinicalTrials.gov API
+CTM_CTGOV_BASE_URL=https://clinicaltrials.gov/api/v2
+CTM_CTGOV_RATE_LIMIT=3.0
+CTM_CTGOV_MAX_RETRIES=2
+CTM_CTGOV_RETRY_BACKOFF_SECONDS=1.0
+
+# Rate limits (per window)
+CTM_INGEST_RATE_LIMIT_REQUESTS=20
+CTM_INGEST_RATE_LIMIT_WINDOW_SECONDS=60
+CTM_SEARCH_INGEST_RATE_LIMIT_REQUESTS=10
+CTM_SEARCH_INGEST_RATE_LIMIT_WINDOW_SECONDS=60
+CTM_REEXTRACT_RATE_LIMIT_REQUESTS=20
+CTM_REEXTRACT_RATE_LIMIT_WINDOW_SECONDS=60
+
+# Extraction / coding
+CTM_CODING_FUZZY_SIMILARITY_THRESHOLD=0.55
+CTM_PIPELINE_VERSION=0.1.0
+CTM_SPACY_MODEL=en_core_sci_lg
+
+# Data paths
+CTM_ABBREVIATION_DICT_PATH=data/dictionaries/onc_abbreviations.jsonl
+CTM_PATTERNS_DIR=data/patterns
+
+# Runtime flags used by container/deploy workflows
+CTM_RUN_MIGRATIONS=1
+
+# -----------------------------------------------------------------------------
+# Frontend environment (copy into frontend/.env.local for local frontend runs)
+# -----------------------------------------------------------------------------
+
+CTM_FRONTEND_API_BASE_URL=http://127.0.0.1:8000/api/v1
+CTM_FRONTEND_API_KEY=local-dev-api-key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install backend dependencies
+        run: |
+          uv venv --python 3.12 .ctm-dev
+          uv pip install --python .ctm-dev/bin/python -e ".[dev]"
+
+      - name: Detect changed Python files
+        id: changed-python
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            **/*.py
+
+      - name: Ruff (changed Python files only)
+        if: steps.changed-python.outputs.any_changed == 'true'
+        run: ./.ctm-dev/bin/ruff check ${{ steps.changed-python.outputs.all_changed_files }}
+
+      - name: Backend tests
+        run: ./.ctm-dev/bin/pytest -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,28 @@
 __pycache__/
 *.pyc
 .env
+.env.local
 *.egg-info/
 dist/
 .ruff_cache/
 .mypy_cache/
 .pytest_cache/
-.superpowers/
-.worktrees/
-.ctm-dev/
 .conda-pkgs/
 .conda-env/
+.ctm-dev/
+.venv/
+.direnv/
 frontend/node_modules/
 frontend/.next/
 frontend/*.tsbuildinfo
-docs/
+frontend/.env.local
 .DS_Store
-.gitnexus
-.claude/
-.claude/*
-AGENTS.md
-CLAUDE.md
+# Local editor / workspace state
+.idea/
+.vscode/
+*.code-workspace
+# Local-only dev compose overrides and lockfiles not adopted by the repo
+docker-compose.override.yml
+uv.lock
+# Internal/Hermes Workspace — never commit plans, notes, or chat history
+.hermes/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Clinical Trial Matching - Architecture
+
+## Overview
+
+Clinical Trial Matching is a full-stack MVP for ingesting ClinicalTrials.gov studies, extracting normalized eligibility criteria, reviewing ambiguous results, generating FHIR previews, and matching normalized patient profiles against stored trial criteria.
+
+At a high level:
+
+`ClinicalTrials.gov ingestion -> canonical trial + criteria extraction -> review + correction -> FHIR projection -> patient intake -> deterministic matching`
+
+## Runtime Components
+
+### Backend
+
+- **Framework:** FastAPI (`app/main.py`)
+- **Configuration:** Pydantic settings in `app/config.py`
+- **Persistence:** SQLAlchemy models in `app/models/database.py`, session setup in `app/db/session.py`, Alembic migrations in `app/db/migrations/`
+- **Primary API surface:** route modules under `app/api/routes/`
+
+### Frontend
+
+- **Framework:** Next.js App Router in `frontend/src/app/`
+- **API access:** server-side client in `frontend/src/lib/api/client.ts`
+- **Shell/components:** reusable UI in `frontend/src/components/`
+
+### Local infrastructure
+
+- `docker-compose.yml` defines `db`, `app`, and `frontend` services for local full-stack runs.
+- `scripts/dev.sh` starts the backend and frontend locally, runs migrations, and syncs coding lookups unless explicitly skipped.
+- Personal compose override files can be kept locally, but they are not part of the committed project surface.
+
+## Backend Module Map
+
+| Path | Purpose | Notable files |
+|------|---------|---------------|
+| `app/api/` | FastAPI routing, schemas, dependencies, errors, OpenAPI helpers | `routes/trials.py`, `routes/patients.py`, `schemas.py`, `dependencies.py` |
+| `app/ingestion/` | ClinicalTrials.gov fetch + normalization pipeline inputs | `ctgov_client.py`, `service.py`, `hasher.py` |
+| `app/extraction/` | Eligibility parsing, classification, decomposition, coding helpers | `pipeline.py`, `criteria_classifier.py`, `section_splitter.py`, `coding/` |
+| `app/fhir/` | Trial-level and criterion-level FHIR projection | `mapper.py`, `criterion_projection.py`, `models.py` |
+| `app/matching/` | Deterministic patient-to-trial matching | `service.py` |
+| `app/models/` | ORM models for persisted application state | `database.py` |
+| `app/db/` | DB session and Alembic migration environment | `session.py`, `migrations/` |
+| `app/scripts/` | Local/admin scripts for seed and verification workflows | `seed.py`, `seed_demo.py`, `curated_corpus_report.py` |
+
+## Current Frontend Route Surface
+
+The committed frontend currently exposes these route entrypoints:
+
+- `/` - operations console landing page
+- `/pipeline` - ingestion and pipeline status
+- `/trials` - trial list/search
+- `/trials/[trialId]` - trial detail, criteria, and FHIR views
+- `/review` - review queue
+- `/patients` - patient list/create flow
+- `/patients/[patientId]` - patient detail and matching actions
+- `/matches/[matchId]` - persisted match result detail
+
+## Extraction and Matching Flow
+
+1. **Ingest** trial records from ClinicalTrials.gov.
+2. **Store** source trial payloads and latest-run-aware pipeline history.
+3. **Extract** normalized criteria from free-text eligibility content.
+4. **Review** ambiguous or blocked criteria through the review queue.
+5. **Project** the latest canonical trial state into FHIR outputs where policy allows.
+6. **Create/update** normalized patient records.
+7. **Match** patients against stored criteria and persist match explanations.
+
+## Repository Shape
+
+```text
+clinical-trial-matching/
+├── app/                    # FastAPI backend, extraction, FHIR, matching, DB
+├── data/                   # Dictionaries, patterns, terminology seed data
+├── frontend/               # Next.js frontend
+├── scripts/                # Local developer scripts
+├── docker-compose.yml      # Committed local stack definition
+├── render.yaml             # Deployment blueprint for backend/database
+├── .env.example            # Documented environment examples
+├── README.md               # Project overview and setup
+└── ARCHITECTURE.md         # This file
+```

--- a/README.md
+++ b/README.md
@@ -60,101 +60,110 @@ The frontend is intended to make that path demoable end to end from one console.
 
 ### Prerequisites
 
-- Python 3.12
+- Python 3.12+
 - Node.js 20+
 - Docker Desktop or a local PostgreSQL instance
-- `npm` available in `PATH`
+- `uv`, `npm`, `curl`, and `lsof` available in `PATH`
 
-### Option A: One-command local startup
+### Quick Start (Recommended)
 
-This is the cleanest local path once dependencies are installed.
+This path matches the setup verified in this repo: install CPython 3.12 with `uv`, create a repo-local virtualenv, install the backend in editable mode, install frontend dependencies, then run the launcher.
 
-1. Start Postgres:
+1. Copy environment templates:
 
-```bash
-docker compose up -d db
-```
+   ```bash
+   cp .env.example .env
+   cp frontend/.env.example frontend/.env.local
+   ```
 
-2. Create or activate a Python environment and install backend dependencies:
+2. Start Postgres:
 
-```bash
-conda create -p ./.ctm-dev python=3.12 -y
-conda activate ./.ctm-dev
-pip install -e ".[dev]"
-```
+   ```bash
+   docker compose up -d db
+   ```
 
-3. Install frontend dependencies:
+3. Install backend dependencies:
 
-```bash
-cd frontend && npm install && cd ..
-```
+   ```bash
+   uv python install 3.12
+   uv venv --python 3.12 .ctm-dev
+   uv pip install --python .ctm-dev/bin/python -e ".[dev]"
+   export PATH="$PWD/.ctm-dev/bin:$PATH"
+   ```
 
-4. Start the stack:
+4. Install frontend dependencies:
 
-```bash
-./scripts/dev.sh
-```
+   ```bash
+   cd frontend && npm install && cd ..
+   ```
 
-The startup path now syncs the coding lookup catalog automatically, so local runs use the current terminology seed without requiring a separate manual seed step for lookups.
+5. Start the dev server:
 
-Default local URLs:
+   ```bash
+   ./scripts/dev.sh
+   ```
 
+   The startup path syncs the coding lookup catalog automatically, so local runs use the current terminology seed.
+
+**Default local URLs:**
 - Frontend: `http://127.0.0.1:3000`
 - Backend: `http://127.0.0.1:8000`
 - Health: `http://127.0.0.1:8000/api/v1/health`
 
-Optional demo data:
-
-```bash
-python -m app.scripts.seed_demo
-```
-
-### Option B: Manual local startup
+### Manual Local Startup
 
 Use this when you want explicit control over each process.
 
-1. Start Postgres:
+1. Copy environment templates:
 
-```bash
-docker compose up -d db
-```
+   ```bash
+   cp .env.example .env
+   cp frontend/.env.example frontend/.env.local
+   ```
 
-2. Create or activate a Python environment and install dependencies:
+2. Start Postgres:
 
-```bash
-conda create -p ./.ctm-dev python=3.12 -y
-conda activate ./.ctm-dev
-pip install -e ".[dev]"
-```
+   ```bash
+   docker compose up -d db
+   ```
 
-3. Run migrations:
+3. Create a Python environment and install dependencies:
 
-```bash
-alembic upgrade head
-```
+   ```bash
+   uv python install 3.12
+   uv venv --python 3.12 .ctm-dev
+   uv pip install --python .ctm-dev/bin/python -e ".[dev]"
+   export PATH="$PWD/.ctm-dev/bin:$PATH"
+   ```
 
-4. Start the backend:
+4. Run migrations:
 
-```bash
-export CTM_API_KEY=local-dev-api-key
-uvicorn app.main:app --reload
-```
+   ```bash
+   alembic upgrade head
+   ```
 
-5. In a second terminal, start the frontend:
+5. Start the backend (in one terminal):
 
-```bash
-cd frontend
-npm install
-export CTM_FRONTEND_API_BASE_URL=http://127.0.0.1:8000/api/v1
-export CTM_FRONTEND_API_KEY=local-dev-api-key
-npm run dev
-```
+   ```bash
+   export CTM_API_KEY=***  # from your .env
+   uvicorn app.main:app --reload
+   ```
 
-6. Optional demo seed:
+6. Start the frontend (in another terminal):
 
-```bash
-python -m app.scripts.seed_demo
-```
+   ```bash
+   cd frontend
+   npm install
+   export CTM_FRONTEND_API_BASE_URL=http://127.0.0.1:8000/api/v1
+   export CTM_FRONTEND_API_KEY=***  # from frontend/.env.local
+   npm run dev
+   ```
+
+7. Optional demo seed:
+
+   ```bash
+   python -m app.scripts.seed_demo
+   ```
 
 ## Full-Stack Containers
 
@@ -165,12 +174,17 @@ docker compose up --build
 ```
 
 This starts:
+- `db` on port `5432`
+- `app` on port `8000`
+- `frontend` on port `3000`
 
-- `db` on `5432`
-- `app` on `8000`
-- `frontend` on `3000`
+Verify the backend is healthy after startup:
 
-Container runtime has been verified locally.
+```bash
+curl -fsS http://localhost:8000/api/v1/health
+```
+
+> **Note:** Personal `docker-compose.override.yml` files are ignored by `.gitignore`. Keep custom overrides local only.
 
 ## Demo Flow
 
@@ -187,8 +201,7 @@ The clean MVP walkthrough is:
 5. Open `Patients`, create or inspect a patient
 6. Run matching and open the persisted match result page
 
-Key frontend routes:
-
+**Key frontend routes:**
 - `/`
 - `/pipeline`
 - `/trials`
@@ -197,56 +210,47 @@ Key frontend routes:
 
 ## Deployment
 
-The intended deployment split is:
+One supported deployment pattern is:
+- frontend on Vercel from `frontend/`
+- backend on Render from the repo root Dockerfile
+- managed Postgres for the application database
 
-- `ctm.omaression.com` -> Vercel frontend from `frontend/`
-- `api.ctm.omaression.com` -> Render backend from the repo root Dockerfile
-- Render Postgres -> `clinical_trials`
+**Example frontend env vars:**
+- `CTM_FRONTEND_API_BASE_URL=https://api.example.com/api/v1`
+- `CTM_FRONTEND_API_KEY=***`
 
-Required Vercel env vars:
-
-- `CTM_FRONTEND_API_BASE_URL=https://api.ctm.omaression.com/api/v1`
-- `CTM_FRONTEND_API_KEY=<same value as Render CTM_API_KEY>`
-
-Required Render env vars:
-
+**Example backend env vars:**
 - `CTM_DATABASE_URL`
 - `CTM_API_KEY`
 - `CTM_RUN_MIGRATIONS=1`
 
-There is also a `render.yaml` blueprint in the repo for the backend/database side.
+There is also a `render.yaml` blueprint in the repo for the backend/database side if you want to use Render.
 
-## Next Steps
+## Roadmap
 
-The remaining roadmap is now narrower and more concrete:
+The following items represent the prioritized next phase of development. These are tracked as issues in the repository and refined as requirements before implementation.
 
-- Terminology and projection gaps:
-  - source safe parent or class concepts for the remaining blocked therapy classes where authoritative concepts exist
-  - improve the remaining genuinely complex medication-exception and washout logic that still deserves review
-  - continue increasing standard FHIR projection coverage without relaxing the current precision policy
-- Corpus-scale validation:
-  - broaden real ClinicalTrials.gov study coverage beyond the current sentinel trials and curated fixture sweep
-  - keep tracking review-required residue, blocked terminology cases, and projection counts as the corpus expands
-  - verify that extraction gains generalize across more oncology and medication-heavy studies
-- Product and deployment polish:
-  - add async/batch ingestion and operational job status handling
-  - add geographic/site-aware matching
-  - harden the public deployment and demo presentation for `ctm.omaression.com`
-  - decide whether any internal-only eligibility categories should ever receive a formal interoperability design
+| Priority | Item | Description |
+|----------|------|-------------|
+| 1 | Terminology gaps | Source safe parent/class concepts for remaining blocked therapy classes |
+| 2 | Corpus validation | Expand beyond sentinel trials; track review residue, blocked terminology, and projection counts |
+| 3 | Product polish | Async/batch ingestion, geographic/site-aware matching, public deployment hardening |
+| 4 | Interoperability | Decide if internal-only eligibility categories need formal FHIR design |
+
+> **Note:** The MVP is complete and functional. The roadmap focuses on production-readiness and coverage expansion.
 
 ## Verification
 
-Recent verification performed in this repository includes:
+Use the following commands to verify a local setup:
 
-- full backend test suite via `pytest`
-- frontend `npm run typecheck`
-- frontend `npm run build`
-- backend Docker build
-- frontend Docker build
-- `docker compose up --build -d` runtime verification
-- curated corpus verification via:
+- **backend tests:** `pytest -q`
+- **frontend typecheck:** `cd frontend && npm run typecheck`
+- **frontend build:** `cd frontend && npm run build`
+- **full stack runtime:** `docker compose up --build -d`
+- **backend health:** `curl -fsS http://127.0.0.1:8000/api/v1/health`
+- **curated corpus report:**
 
-```bash
-./.ctm-dev/bin/python -m app.scripts.curated_corpus_report
-./.ctm-dev/bin/python -m app.scripts.curated_corpus_report --format json
-```
+  ```bash
+  ./.ctm-dev/bin/python -m app.scripts.curated_corpus_report
+  ./.ctm-dev/bin/python -m app.scripts.curated_corpus_report --format json
+  ```

--- a/app/extraction/constants.py
+++ b/app/extraction/constants.py
@@ -1,0 +1,55 @@
+"""Shared terminology constants used by extraction-adjacent modules."""
+
+PD_1_THERAPY_SYNONYMS = (
+    "pd-1 therapy",
+    "pd 1 therapy",
+    "pd-1 inhibitor therapy",
+    "pd 1 inhibitor therapy",
+    "programmed cell death protein 1 therapy",
+    "programmed cell death protein 1 (pd-1) therapy",
+)
+
+PD_L1_THERAPY_SYNONYMS = (
+    "pd-l1 therapy",
+    "pd l1 therapy",
+    "pd-l1 inhibitor therapy",
+    "pd l1 inhibitor therapy",
+    "programmed death-ligand 1 therapy",
+    "programmed death ligand 1 therapy",
+    "programmed death-ligand 1 (pd-l1) therapy",
+    "programmed death ligand 1 (pd l1) therapy",
+)
+
+RECOGNIZED_MEDICATION_CLASS_TERMS = frozenset(
+    {
+        "pd-1 therapy",
+        "pd-1/pd-l1 therapy",
+        "pd-1/pd-l1 inhibitor therapy",
+        "pd-l1 therapy",
+        "kras-targeted therapy",
+        "agent targeting kras",
+        "systemic corticosteroids",
+        "live-attenuated vaccine",
+        "live vaccine",
+        "live or live-attenuated vaccine",
+        "cyp3a4 inhibitors/inducers",
+        "platinum-based chemotherapy",
+    }
+)
+
+AMBIGUOUS_MEDICATION_CLASS_HINTS = frozenset(
+    {
+        "therapy",
+        "vaccine",
+        "corticosteroid",
+        "steroid",
+        "chemotherapy",
+        "inhibitor",
+        "inducer",
+        "immunosuppressive",
+        "targeted",
+        "targeting",
+        "antibody",
+        "agent",
+    }
+)

--- a/app/extraction/patterns.py
+++ b/app/extraction/patterns.py
@@ -1,0 +1,59 @@
+"""Common regex patterns for the extraction pipeline."""
+
+import re
+
+# Long-form drug patterns (e.g., PD-L1 full spelling variations)
+LONG_FORM_DRUG_PATTERNS = (
+    re.compile(
+        r"programmed\s+death(?:-|\s+)ligand\s+1\s*\(\s*PD(?:-|\s*)L1\s*\)\s*therapy",
+        re.I,
+    ),
+)
+
+# Progression criteria - "progression after receiving..."
+PROGRESSION_AFTER_RECEIVING_PATTERN = re.compile(
+    r"^(?P<prefix>.*?\b(?:documented\s+disease\s+progression|disease\s+progression|progression)\b.*?\bafter\b\s+\b(?:receiving|receipt\s+of)\b)\s+(?P<tail>.+)$",
+    re.I,
+)
+
+# Progression with "including" construction
+INCLUDING_PROGRESSION_PATTERN = re.compile(
+    r"^(?P<lemma>\*?\s*(?:has|have))\s+(?P<head>.+?),\s+including\s+(?P<tail>disease\s+progression\s+after\s+receiving.+)$",
+    re.I | re.S,
+)
+
+# "of the following types" enumeration patterns
+FOLLOWING_TYPES_PATTERN = re.compile(
+    r"^(?P<prefix>.*?)(?P<intro>\b(?:of\s+the\s+following\s+types|following\s+types|following\s+histologies)\s*:)\s*"
+    r"(?P<items>.+?)(?P<tail>,?\s*(?:who|that)\b.+)$",
+    re.I | re.S,
+)
+
+# Diagnosis or medication split pattern
+DIAGNOSIS_MEDICATION_SPLIT_PATTERN = re.compile(
+    r"^(?P<bullet>\*?\s*)(?P<lemma>has|have)\s+(?:a\s+diagnosis\s+of|diagnosis\s+of)\s+"
+    r"(?P<diagnosis>.+?)\s+or\s+(?P<medication>(?:is\s+receiving|receiving|using|use\s+of).+)$",
+    re.I,
+)
+
+# Medication verb pattern (is receiving, receiving, etc.)
+MEDICATION_LEMMA_PATTERN = re.compile(
+    r"^(?P<verb>is\s+receiving|receiving|using|use\s+of)\s+(?P<body>.+)$",
+    re.I,
+)
+
+# Temporal tail indicators (within, at least, prior to, etc.)
+TEMPORAL_TAIL_PATTERN = re.compile(
+    r"\b(?:within|at\s+least|no\s+more\s+than|prior\s+to|since|more\s+than|>)\b.+$",
+    re.I,
+)
+
+# Medication signals (vaccine, corticosteroid, immunosuppressive, etc.)
+MEDICATION_SIGNAL_PATTERN = re.compile(
+    r"\b(?:vaccine|corticosteroid|steroid\s+therapy|immunosuppressive\s+therapy|"
+    r"immunosuppressive\s+medications?|immunosuppressants?|cyp[0-9a-z-]+)\b",
+    re.I,
+)
+
+# Enumeration connectors (comma, or, and/or)
+ENUMERATION_CONNECTOR_PATTERN = re.compile(r"\s*(?:,\s*|\bor\b\s*|\band/or\b\s*)", re.I)

--- a/app/extraction/pipeline.py
+++ b/app/extraction/pipeline.py
@@ -8,47 +8,35 @@ from app.config import settings
 from app.extraction.abbreviation_resolver import AbbreviationResolver
 from app.extraction.criteria_classifier import RuleBasedClassifier
 from app.extraction.entity_ruler import load_entity_ruler
+from app.extraction.patterns import (
+    DIAGNOSIS_MEDICATION_SPLIT_PATTERN as _DIAGNOSIS_MEDICATION_SPLIT_PATTERN,
+)
+from app.extraction.patterns import (
+    ENUMERATION_CONNECTOR_PATTERN as _ENUMERATION_CONNECTOR_PATTERN,
+)
+from app.extraction.patterns import (
+    FOLLOWING_TYPES_PATTERN as _FOLLOWING_TYPES_PATTERN,
+)
+from app.extraction.patterns import (
+    INCLUDING_PROGRESSION_PATTERN as _INCLUDING_PROGRESSION_PATTERN,
+)
+from app.extraction.patterns import (
+    LONG_FORM_DRUG_PATTERNS as _LONG_FORM_DRUG_PATTERNS,
+)
+from app.extraction.patterns import (
+    MEDICATION_LEMMA_PATTERN as _MEDICATION_LEMMA_PATTERN,
+)
+from app.extraction.patterns import (
+    MEDICATION_SIGNAL_PATTERN as _MEDICATION_SIGNAL_PATTERN,
+)
+from app.extraction.patterns import (
+    PROGRESSION_AFTER_RECEIVING_PATTERN as _PROGRESSION_AFTER_RECEIVING_PATTERN,
+)
+from app.extraction.patterns import (
+    TEMPORAL_TAIL_PATTERN as _TEMPORAL_TAIL_PATTERN,
+)
 from app.extraction.section_splitter import SectionSplitter
 from app.extraction.types import ClassifiedCriterion, CriterionText, Entity, PipelineResult
-
-_LONG_FORM_DRUG_PATTERNS = (
-    re.compile(
-        r"programmed\s+death(?:-|\s+)ligand\s+1\s*\(\s*PD(?:-|\s*)L1\s*\)\s*therapy",
-        re.I,
-    ),
-)
-_PROGRESSION_AFTER_RECEIVING_PATTERN = re.compile(
-    r"^(?P<prefix>.*?\b(?:documented\s+disease\s+progression|disease\s+progression|progression)\b.*?\bafter\b\s+\b(?:receiving|receipt\s+of)\b)\s+(?P<tail>.+)$",
-    re.I,
-)
-_INCLUDING_PROGRESSION_PATTERN = re.compile(
-    r"^(?P<lemma>\*?\s*(?:has|have))\s+(?P<head>.+?),\s+including\s+(?P<tail>disease\s+progression\s+after\s+receiving.+)$",
-    re.I | re.S,
-)
-_FOLLOWING_TYPES_PATTERN = re.compile(
-    r"^(?P<prefix>.*?)(?P<intro>\b(?:of\s+the\s+following\s+types|following\s+types|following\s+histologies)\s*:)\s*"
-    r"(?P<items>.+?)(?P<tail>,?\s*(?:who|that)\b.+)$",
-    re.I | re.S,
-)
-_DIAGNOSIS_MEDICATION_SPLIT_PATTERN = re.compile(
-    r"^(?P<bullet>\*?\s*)(?P<lemma>has|have)\s+(?:a\s+diagnosis\s+of|diagnosis\s+of)\s+"
-    r"(?P<diagnosis>.+?)\s+or\s+(?P<medication>(?:is\s+receiving|receiving|using|use\s+of).+)$",
-    re.I,
-)
-_MEDICATION_LEMMA_PATTERN = re.compile(
-    r"^(?P<verb>is\s+receiving|receiving|using|use\s+of)\s+(?P<body>.+)$",
-    re.I,
-)
-_TEMPORAL_TAIL_PATTERN = re.compile(
-    r"\b(?:within|at\s+least|no\s+more\s+than|prior\s+to|since|more\s+than|>)\b.+$",
-    re.I,
-)
-_MEDICATION_SIGNAL_PATTERN = re.compile(
-    r"\b(?:vaccine|corticosteroid|steroid\s+therapy|immunosuppressive\s+therapy|"
-    r"immunosuppressive\s+medications?|immunosuppressants?|cyp[0-9a-z-]+)\b",
-    re.I,
-)
-_ENUMERATION_CONNECTOR_PATTERN = re.compile(r"\s*(?:,\s*|\bor\b\s*|\band/or\b\s*)", re.I)
 
 
 class ExtractionPipeline:

--- a/app/fhir/criterion_projection.py
+++ b/app/fhir/criterion_projection.py
@@ -7,6 +7,10 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.extraction.constants import (
+    AMBIGUOUS_MEDICATION_CLASS_HINTS,
+    RECOGNIZED_MEDICATION_CLASS_TERMS,
+)
 from app.fhir.models import Annotation, CodeableConcept, Coding, MedicationStatement, Reference
 from app.models.database import CodingLookup
 from app.scripts.seed import MEDRT_DRUG_CLASSES, NCI_DRUGS, RXNORM_DRUGS, SNOMED_MEDICATION_CLASSES
@@ -23,34 +27,6 @@ _SYSTEM_URIS = {
     "nci_thesaurus": NCIT_SYSTEM_URI,
 }
 _MEDICATION_PROJECTION_CATEGORIES = {"prior_therapy", "concomitant_medication"}
-_RAW_RECOGNIZED_CLASS_TERMS = {
-    "pd-1 therapy",
-    "pd-1/pd-l1 therapy",
-    "pd-1/pd-l1 inhibitor therapy",
-    "pd-l1 therapy",
-    "kras-targeted therapy",
-    "agent targeting kras",
-    "systemic corticosteroids",
-    "live-attenuated vaccine",
-    "live vaccine",
-    "live or live-attenuated vaccine",
-    "cyp3a4 inhibitors/inducers",
-    "platinum-based chemotherapy",
-}
-_AMBIGUOUS_CLASS_HINTS = (
-    "therapy",
-    "vaccine",
-    "corticosteroid",
-    "steroid",
-    "chemotherapy",
-    "inhibitor",
-    "inducer",
-    "immunosuppressive",
-    "targeted",
-    "targeting",
-    "antibody",
-    "agent",
-)
 _NAMED_DRUG_WRAPPER_PATTERN = re.compile(
     r"\bcontaining\s+(?:treatments?|therap(?:y|ies)|regimens?)\b",
     re.I,
@@ -456,4 +432,5 @@ def _contains_normalized_phrase(text: str, phrase: str) -> bool:
     return f" {phrase} " in f" {text} "
 
 
-_RECOGNIZED_CLASS_TERMS = {_normalize_term(term) for term in _RAW_RECOGNIZED_CLASS_TERMS}
+_RECOGNIZED_CLASS_TERMS = {_normalize_term(term) for term in RECOGNIZED_MEDICATION_CLASS_TERMS}
+_AMBIGUOUS_CLASS_HINTS = tuple(AMBIGUOUS_MEDICATION_CLASS_HINTS)

--- a/app/scripts/seed.py
+++ b/app/scripts/seed.py
@@ -1,6 +1,7 @@
 """Seed the database with coding lookups for entity resolution."""
 
 from app.db.session import SessionLocal
+from app.extraction.constants import PD_1_THERAPY_SYNONYMS, PD_L1_THERAPY_SYNONYMS
 from app.models.database import CodingLookup
 
 # MeSH disease codes
@@ -227,31 +228,24 @@ NCI_DRUGS = [
         ],
     ),
     (
-        "C178320",
-        "anti-PD-1 monoclonal antibody",
+        "C122080",
+        "Systemic Corticosteroid Therapy",
         [
-            "pd-1 therapy",
-            "pd 1 therapy",
-            "pd-1 inhibitor therapy",
-            "pd 1 inhibitor therapy",
-            "programmed cell death protein 1 therapy",
-            "programmed cell death protein 1 (pd-1) therapy",
+            "systemic corticosteroid",
+            "systemic corticosteroids",
         ],
     ),
     (
-        "C128057",
-        "anti-PD-L1 monoclonal antibody",
+        "C97116",
+        "Attenuated Live Vaccine",
         [
-            "pd-l1 therapy",
-            "pd l1 therapy",
-            "pd-l1 inhibitor therapy",
-            "pd l1 inhibitor therapy",
-            "programmed death-ligand 1 therapy",
-            "programmed death ligand 1 therapy",
-            "programmed death-ligand 1 (pd-l1) therapy",
-            "programmed death ligand 1 (pd l1) therapy",
+            "live vaccine",
+            "live-attenuated vaccine",
+            "live or live-attenuated vaccine",
         ],
     ),
+    ("C178320", "anti-PD-1 monoclonal antibody", list(PD_1_THERAPY_SYNONYMS)),
+    ("C128057", "anti-PD-L1 monoclonal antibody", list(PD_L1_THERAPY_SYNONYMS)),
     ("C1794", "Capecitabine", ["xeloda"]),
     ("C1900", "Irinotecan", ["camptosar"]),
     ("C510", "Fluorouracil", ["5-fu", "5fu", "5 fluorouracil"]),

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,71 @@
+# Clinical Trial Matching Frontend
+
+This frontend is the Next.js operations console for the Clinical Trial Matching MVP.
+
+## Prerequisites
+
+- Node.js 20+
+- A reachable backend API
+- `npm` available in `PATH`
+
+## Local setup
+
+From `frontend/`:
+
+```bash
+npm install
+```
+
+Create `frontend/.env.local` with:
+
+```bash
+CTM_FRONTEND_API_BASE_URL=http://127.0.0.1:8000/api/v1
+CTM_FRONTEND_API_KEY=local-dev-api-key
+```
+
+The repo root `.env.example` documents both backend/root variables and the frontend variables you should copy into `frontend/.env.local`.
+
+## Development commands
+
+```bash
+npm run dev
+npm run build
+npm run start
+npm run lint
+npm run typecheck
+npm run generate:openapi
+```
+
+## Current route map
+
+- `/` - console landing page
+- `/pipeline` - ingest trials and inspect pipeline status/runs
+- `/trials` - trial list/search
+- `/trials/[trialId]` - trial detail, criteria, and FHIR views
+- `/review` - review queue and correction flow
+- `/patients` - patient list/create flow
+- `/patients/[patientId]` - patient detail and match actions
+- `/matches/[matchId]` - persisted match result detail
+
+## Current source layout
+
+```text
+frontend/
+├── src/app/         # App Router pages, layouts, and server actions
+├── src/components/  # Reusable UI components
+├── src/lib/         # API client, config, shared helpers, types
+└── scripts/         # Frontend support scripts
+```
+
+## API integration notes
+
+- The frontend uses server-side fetches through `src/lib/api/client.ts`.
+- `CTM_FRONTEND_API_BASE_URL` is required.
+- `CTM_FRONTEND_API_KEY` is only required for protected operations; when present it is sent as `X-API-Key`.
+
+## Stack
+
+- Next.js 15 App Router
+- React 19
+- TypeScript
+- Tailwind CSS

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -693,18 +693,18 @@ class TestCriterionFHIRProjections:
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 8
-        assert data["breakdown_by_status"]["projected"] == 6
-        assert data["breakdown_by_status"]["blocked_missing_class_code"] == 2
-        assert data["breakdown_by_resource_type"]["MedicationStatement"] == 6
-        assert data["breakdown_by_resource_type"]["none"] == 2
+        assert data["breakdown_by_status"]["projected"] == 7
+        assert data["breakdown_by_status"]["blocked_missing_class_code"] == 1
+        assert data["breakdown_by_resource_type"]["MedicationStatement"] == 7
+        assert data["breakdown_by_resource_type"]["none"] == 1
 
         projected = [item for item in data["items"] if item["projection_status"] == "projected"]
         blocked = [item for item in data["items"] if item["projection_status"] == "blocked_missing_class_code"]
         projected_codes = {item["code"] for item in projected}
         blocked_terms = {item["normalized_term"] for item in blocked}
 
-        assert projected_codes == {"8640", "28031", "6135", "282446", "121243", "C178320"}
-        assert blocked_terms == {"systemic corticosteroids", "cyp3a4 inhibitors inducers"}
+        assert projected_codes == {"8640", "28031", "6135", "282446", "121243", "C122080", "C178320"}
+        assert blocked_terms == {"cyp3a4 inhibitors inducers"}
         assert all(item["resource_type"] == "MedicationStatement" for item in projected)
         systems = {
             item["resource"]["medicationCodeableConcept"]["coding"][0]["system"]
@@ -742,13 +742,21 @@ class TestCriterionFHIRProjections:
         data = response.json()
         assert data["total"] == 2
         assert data["breakdown_by_status"] == {
-            "blocked_missing_class_code": 1,
-            "projected": 1,
+            "projected": 2,
         }
         assert data["breakdown_by_resource_type"] == {
-            "MedicationStatement": 1,
-            "none": 1,
+            "MedicationStatement": 2,
         }
+
+        systemic_projection = next(
+            item for item in data["items"] if item["normalized_term"] == "systemic corticosteroids"
+        )
+        assert systemic_projection["projection_status"] == "projected"
+        assert systemic_projection["code"] == "C122080"
+        assert (
+            systemic_projection["resource"]["medicationCodeableConcept"]["coding"][0]["system"]
+            == "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+        )
 
         prednisone_projection = next(item for item in data["items"] if item["normalized_term"] == "prednisone")
         assert prednisone_projection["projection_status"] == "projected"
@@ -759,6 +767,42 @@ class TestCriterionFHIRProjections:
             == "http://www.nlm.nih.gov/research/umls/rxnorm"
         )
         assert prednisone_projection["resource"]["derivedFrom"][0]["reference"] == f"ResearchStudy/{trial.id}"
+
+    def test_single_criterion_fhir_projections_include_live_vaccine_safe_parent_class(self, client, db_session):
+        trial, _, _, _ = _seed_trial(db_session)
+        sync_coding_lookups(db_session)
+        _, created = _add_completed_run(
+            db_session,
+            trial,
+            [
+                {
+                    "type": "exclusion",
+                    "category": "concomitant_medication",
+                    "original_text": "No live or live-attenuated vaccine within 30 days before enrollment",
+                    "value_text": "live or live-attenuated vaccine",
+                    "timeframe_operator": "within",
+                    "timeframe_value": 30,
+                    "timeframe_unit": "days",
+                }
+            ],
+        )
+
+        response = client.get(f"/api/v1/criteria/{created[0].id}/fhir-projections")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        vaccine_projection = data["items"][0]
+        assert vaccine_projection["normalized_term"] == "live or live attenuated vaccine"
+        assert vaccine_projection["projection_status"] == "projected"
+        assert vaccine_projection["terminology_status"] == "nci_thesaurus_grounded"
+        assert vaccine_projection["code"] == "C97116"
+        assert vaccine_projection["display"] == "Attenuated Live Vaccine"
+        assert vaccine_projection["resource_type"] == "MedicationStatement"
+        assert (
+            vaccine_projection["resource"]["medicationCodeableConcept"]["coding"][0]["system"]
+            == "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+        )
 
     def test_criterion_fhir_projections_not_found(self, client):
         response = client.get(f"/api/v1/criteria/{uuid.uuid4()}/fhir-projections")

--- a/tests/integration/test_curated_corpus_sweep.py
+++ b/tests/integration/test_curated_corpus_sweep.py
@@ -59,8 +59,8 @@ def test_curated_corpus_report_summarizes_fixture_metrics():
     assert report["summary"]["criteria_count"] == 12
     assert report["summary"]["review_required_count"] == 0
     assert report["summary"]["structurally_exportable_fhir_count"] == 2
-    assert report["summary"]["medication_statement_projected_count"] == 6
-    assert report["summary"]["blocked_missing_class_code_count"] == 4
+    assert report["summary"]["medication_statement_projected_count"] == 8
+    assert report["summary"]["blocked_missing_class_code_count"] == 2
     assert report["summary"]["blocked_missing_rxnorm_count"] == 0
     assert report["summary"]["review_required_ambiguous_class_count"] == 0
     fixture_names = [fixture["fixture"] for fixture in report["fixtures"]]
@@ -78,8 +78,26 @@ def test_curated_corpus_report_summarizes_fixture_metrics():
         fixture for fixture in report["fixtures"] if fixture["fixture"] == "medication_exception_logic"
     )
     assert medication_fixture["structurally_exportable_fhir_count"] == 0
-    assert medication_fixture["medication_statement_projected_count"] == 5
-    assert medication_fixture["blocked_missing_class_code_count"] == 3
+    assert medication_fixture["medication_statement_projected_count"] == 7
+    assert medication_fixture["blocked_missing_class_code_count"] == 1
+    assert medication_fixture["projection_status_distribution"] == {
+        "blocked_missing_class_code": 1,
+        "projected": 7,
+    }
+
+
+def test_curated_corpus_report_keeps_cyp3a4_class_blocked_while_projecting_safe_classes():
+    report = build_curated_corpus_report(["medication_exception_logic"])
+
+    assert report["summary"]["medication_statement_projected_count"] == 7
+    assert report["summary"]["blocked_missing_class_code_count"] == 1
+
+    fixture = report["fixtures"][0]
+    assert fixture["fixture"] == "medication_exception_logic"
+    assert fixture["projection_status_distribution"] == {
+        "blocked_missing_class_code": 1,
+        "projected": 7,
+    }
 
 
 def test_curated_corpus_report_tracks_projected_and_blocked_line_of_therapy_clauses():

--- a/tests/unit/test_criterion_projection.py
+++ b/tests/unit/test_criterion_projection.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from app.extraction.types import Entity
 from app.fhir.criterion_projection import CriterionProjectionMapper
 
@@ -33,15 +35,25 @@ def _make_criterion(**kwargs):
     return criterion
 
 
-def test_named_drug_allowance_projects_to_medication_statement():
+def test_systemic_corticosteroid_class_and_named_allowance_project_to_medication_statements():
     mapper = CriterionProjectionMapper()
     criterion = _make_criterion()
 
     projections = mapper.project_criterion(criterion)
 
     statuses = {projection.normalized_term: projection.projection_status for projection in projections}
-    assert statuses["systemic corticosteroids"] == "blocked_missing_class_code"
+    assert statuses["systemic corticosteroids"] == "projected"
     assert statuses["prednisone"] == "projected"
+
+    systemic_projection = next(
+        projection for projection in projections if projection.normalized_term == "systemic corticosteroids"
+    )
+    assert systemic_projection.resource_type == "MedicationStatement"
+    assert systemic_projection.terminology_status == "nci_thesaurus_grounded"
+    assert systemic_projection.code == "C122080"
+    assert systemic_projection.resource["medicationCodeableConcept"]["coding"][0]["system"] == (
+        "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+    )
 
     prednisone_projection = next(
         projection for projection in projections if projection.normalized_term == "prednisone"
@@ -52,6 +64,62 @@ def test_named_drug_allowance_projects_to_medication_statement():
     assert prednisone_projection.resource["medicationCodeableConcept"]["coding"][0]["system"] == (
         "http://www.nlm.nih.gov/research/umls/rxnorm"
     )
+
+
+@pytest.mark.parametrize(
+    "mention_text",
+    [
+        "live vaccine",
+        "live-attenuated vaccine",
+        "live or live-attenuated vaccine",
+    ],
+)
+def test_live_vaccine_variants_project_to_safe_parent_class(mention_text: str):
+    mapper = CriterionProjectionMapper()
+    criterion = _make_criterion(
+        original_text=f"No {mention_text} within 30 days before enrollment",
+        value_text=mention_text,
+        entities=[Entity(text=mention_text, label="DRUG", start=3, end=3 + len(mention_text))],
+        allowance_text=None,
+        timeframe_operator="within",
+        timeframe_value=30.0,
+        timeframe_unit="days",
+    )
+
+    projections = mapper.project_criterion(criterion)
+
+    assert len(projections) == 1
+    assert projections[0].mention_text == mention_text
+    assert projections[0].projection_status == "projected"
+    assert projections[0].terminology_status == "nci_thesaurus_grounded"
+    assert projections[0].review_required is False
+    assert projections[0].code == "C97116"
+    assert projections[0].resource_type == "MedicationStatement"
+    assert projections[0].resource["medicationCodeableConcept"]["coding"][0]["system"] == (
+        "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+    )
+
+
+def test_generic_vaccine_term_remains_review_required_for_safety():
+    mapper = CriterionProjectionMapper()
+    criterion = _make_criterion(
+        original_text="No vaccine within 30 days before enrollment",
+        value_text="vaccine",
+        entities=[Entity(text="vaccine", label="DRUG", start=3, end=10)],
+        allowance_text=None,
+        timeframe_operator="within",
+        timeframe_value=30.0,
+        timeframe_unit="days",
+    )
+
+    projections = mapper.project_criterion(criterion)
+
+    assert len(projections) == 1
+    assert projections[0].normalized_term == "vaccine"
+    assert projections[0].projection_status == "review_required_ambiguous_class"
+    assert projections[0].terminology_status == "ambiguous_class_no_safe_code"
+    assert projections[0].review_required is True
+    assert projections[0].resource is None
 
 
 def test_safe_pd_1_therapy_class_projects_to_medication_statement():
@@ -144,3 +212,26 @@ def test_investigational_agent_projects_to_safe_parent_class_with_verbatim_text(
     assert projections[0].terminology_status == "nci_thesaurus_grounded"
     assert projections[0].code == "C202579"
     assert projections[0].resource["medicationCodeableConcept"]["text"] == "investigational agent"
+
+
+def test_cyp3a4_inducer_inhibitor_class_remains_blocked_pending_safe_source():
+    mapper = CriterionProjectionMapper()
+    criterion = _make_criterion(
+        original_text="No concurrent CYP3A4 inhibitors/inducers within 7 days",
+        value_text="cyp3a4 inhibitors/inducers",
+        entities=[Entity(text="CYP3A4 inhibitors/inducers", label="DRUG", start=14, end=40)],
+        allowance_text=None,
+        exception_entities=[],
+        timeframe_operator="within",
+        timeframe_value=7.0,
+        timeframe_unit="days",
+    )
+
+    projections = mapper.project_criterion(criterion)
+
+    assert len(projections) == 1
+    assert projections[0].normalized_term == "cyp3a4 inhibitors inducers"
+    assert projections[0].projection_status == "blocked_missing_class_code"
+    assert projections[0].terminology_status == "recognized_class_missing_safe_code"
+    assert projections[0].review_required is True
+    assert projections[0].resource is None


### PR DESCRIPTION
## Summary
- lock in regression coverage for the safe medication terminology slice
- clean up local-only repo artifacts and refresh setup/docs to match the actual project
- add GitHub Actions CI for backend and frontend verification

## Commits
- `test(projections): lock in safe terminology regression coverage`
- `docs(setup): clean up local-only artifacts and install guidance`
- `ci(github-actions): add backend and frontend verification workflow`

## Validation
- `ruff check tests/unit/test_criterion_projection.py tests/integration/test_curated_corpus_sweep.py tests/integration/test_api_endpoints.py`
- `pytest tests/unit/test_criterion_projection.py tests/integration/test_curated_corpus_sweep.py tests/integration/test_api_endpoints.py -q`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`

## Notes
- keeps `.hermes/` and other local-only workspace artifacts out of version control
- removes lockfile churn from this change set
- CI uses the repo's verified Python 3.12 + `uv` setup pattern rather than depending on a committed `uv.lock`
