### PR TITLE
ci(github-actions): refresh actions for node 24 readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install backend dependencies
         run: |
@@ -30,7 +30,7 @@ jobs:
 
       - name: Detect changed Python files
         id: changed-python
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             **/*.py
@@ -49,10 +49,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## Summary
- bump core GitHub Actions to current stable releases with Node 24-ready runtimes
- move `astral-sh/setup-uv` to an immutable release tag
- keep existing backend/frontend CI behavior unchanged

## Changes
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-python@v5` -> `actions/setup-python@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`
- `astral-sh/setup-uv@v3` -> `astral-sh/setup-uv@v8.1.0`
- `tj-actions/changed-files@v45` -> `tj-actions/changed-files@v47`

## Verification
- YAML parses successfully locally
- workflow behavior intentionally unchanged aside from action version refreshes

Created after publishing release `v0.1.0`.
