### PR TITLE
feat(reporting): surface blocked terminology class gaps in corpus reports

### DIFF
--- a/app/scripts/curated_corpus_report.py
+++ b/app/scripts/curated_corpus_report.py
@@ -37,6 +37,7 @@ def build_curated_corpus_report(fixture_names: list[str] | None = None) -> dict[
     total_medication_statement_projected = 0
     total_blocked_missing_rxnorm = 0
     total_blocked_missing_class_code = 0
+    summary_blocked_missing_class_code_terms: Counter[str] = Counter()
     total_review_required_ambiguous_class = 0
     total_review_required = 0
     total_uncoded_accepted = 0
@@ -62,6 +63,11 @@ def build_curated_corpus_report(fixture_names: list[str] | None = None) -> dict[
         projection_resource_counts = Counter(
             projection.resource_type or "none" for projection in projections
         )
+        blocked_missing_class_code_terms = Counter(
+            projection.normalized_term
+            for projection in projections
+            if projection.projection_status == "blocked_missing_class_code" and projection.normalized_term
+        )
         uncoded_accepted = sum(
             1
             for criterion in result.criteria
@@ -78,6 +84,7 @@ def build_curated_corpus_report(fixture_names: list[str] | None = None) -> dict[
             "medication_statement_projected_count": projection_resource_counts["MedicationStatement"],
             "blocked_missing_rxnorm_count": projection_status_counts["blocked_missing_rxnorm"],
             "blocked_missing_class_code_count": projection_status_counts["blocked_missing_class_code"],
+            "blocked_missing_class_code_terms": dict(sorted(blocked_missing_class_code_terms.items())),
             "review_required_ambiguous_class_count": projection_status_counts["review_required_ambiguous_class"],
             "category_distribution": dict(sorted(category_counts.items())),
             "projection_status_distribution": dict(sorted(projection_status_counts.items())),
@@ -90,6 +97,7 @@ def build_curated_corpus_report(fixture_names: list[str] | None = None) -> dict[
         total_medication_statement_projected += projection_resource_counts["MedicationStatement"]
         total_blocked_missing_rxnorm += projection_status_counts["blocked_missing_rxnorm"]
         total_blocked_missing_class_code += projection_status_counts["blocked_missing_class_code"]
+        summary_blocked_missing_class_code_terms.update(blocked_missing_class_code_terms)
         total_review_required_ambiguous_class += projection_status_counts["review_required_ambiguous_class"]
         total_review_required += result.review_required_count
         total_uncoded_accepted += uncoded_accepted
@@ -105,6 +113,7 @@ def build_curated_corpus_report(fixture_names: list[str] | None = None) -> dict[
             "medication_statement_projected_count": total_medication_statement_projected,
             "blocked_missing_rxnorm_count": total_blocked_missing_rxnorm,
             "blocked_missing_class_code_count": total_blocked_missing_class_code,
+            "blocked_missing_class_code_terms": dict(sorted(summary_blocked_missing_class_code_terms.items())),
             "review_required_ambiguous_class_count": total_review_required_ambiguous_class,
             "uncoded_but_accepted_count": total_uncoded_accepted,
             "category_distribution": dict(sorted(summary_categories.items())),
@@ -125,6 +134,10 @@ def render_markdown_report(report: dict[str, Any]) -> str:
             f"- MedicationStatement projections: {summary['medication_statement_projected_count']}",
             f"- Blocked missing RxNorm: {summary['blocked_missing_rxnorm_count']}",
             f"- Blocked missing class code: {summary['blocked_missing_class_code_count']}",
+            (
+                "- Blocked missing class code terms: "
+                f"{json.dumps(summary['blocked_missing_class_code_terms'], sort_keys=True)}"
+            ),
             f"- Review-required ambiguous classes: {summary['review_required_ambiguous_class_count']}",
             f"- Uncoded but accepted: {summary['uncoded_but_accepted_count']}",
             "",
@@ -143,6 +156,10 @@ def render_markdown_report(report: dict[str, Any]) -> str:
                 f"- MedicationStatement projections: {fixture['medication_statement_projected_count']}",
                 f"- Blocked missing RxNorm: {fixture['blocked_missing_rxnorm_count']}",
                 f"- Blocked missing class code: {fixture['blocked_missing_class_code_count']}",
+                (
+                    "- Blocked missing class code terms: "
+                    f"{json.dumps(fixture['blocked_missing_class_code_terms'], sort_keys=True)}"
+                ),
                 f"- Review-required ambiguous classes: {fixture['review_required_ambiguous_class_count']}",
                 f"- Uncoded but accepted: {fixture['uncoded_but_accepted_count']}",
                 f"- Categories: {json.dumps(fixture['category_distribution'], sort_keys=True)}",

--- a/tests/integration/test_curated_corpus_sweep.py
+++ b/tests/integration/test_curated_corpus_sweep.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from app.extraction.pipeline import ExtractionPipeline
-from app.scripts.curated_corpus_report import build_curated_corpus_report
+from app.scripts.curated_corpus_report import build_curated_corpus_report, render_markdown_report
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "sample_eligibility_texts"
 
@@ -61,8 +61,17 @@ def test_curated_corpus_report_summarizes_fixture_metrics():
     assert report["summary"]["structurally_exportable_fhir_count"] == 2
     assert report["summary"]["medication_statement_projected_count"] == 8
     assert report["summary"]["blocked_missing_class_code_count"] == 2
+    assert report["summary"]["blocked_missing_class_code_terms"] == {
+        "agent targeting kras": 1,
+        "cyp3a4 inhibitors inducers": 1,
+    }
     assert report["summary"]["blocked_missing_rxnorm_count"] == 0
     assert report["summary"]["review_required_ambiguous_class_count"] == 0
+    rendered = render_markdown_report(report)
+    assert (
+        '- Blocked missing class code terms: {"agent targeting kras": 1, "cyp3a4 inhibitors inducers": 1}'
+        in rendered
+    )
     fixture_names = [fixture["fixture"] for fixture in report["fixtures"]]
     assert fixture_names == ["therapy_class_and_procedures", "medication_exception_logic"]
 
@@ -72,6 +81,7 @@ def test_curated_corpus_report_summarizes_fixture_metrics():
     assert therapy_fixture["structurally_exportable_fhir_count"] == 2
     assert therapy_fixture["medication_statement_projected_count"] == 1
     assert therapy_fixture["blocked_missing_class_code_count"] == 1
+    assert therapy_fixture["blocked_missing_class_code_terms"] == {"agent targeting kras": 1}
     assert therapy_fixture["review_required_ambiguous_class_count"] == 0
 
     medication_fixture = next(
@@ -80,6 +90,7 @@ def test_curated_corpus_report_summarizes_fixture_metrics():
     assert medication_fixture["structurally_exportable_fhir_count"] == 0
     assert medication_fixture["medication_statement_projected_count"] == 7
     assert medication_fixture["blocked_missing_class_code_count"] == 1
+    assert medication_fixture["blocked_missing_class_code_terms"] == {"cyp3a4 inhibitors inducers": 1}
     assert medication_fixture["projection_status_distribution"] == {
         "blocked_missing_class_code": 1,
         "projected": 7,
@@ -91,9 +102,11 @@ def test_curated_corpus_report_keeps_cyp3a4_class_blocked_while_projecting_safe_
 
     assert report["summary"]["medication_statement_projected_count"] == 7
     assert report["summary"]["blocked_missing_class_code_count"] == 1
+    assert report["summary"]["blocked_missing_class_code_terms"] == {"cyp3a4 inhibitors inducers": 1}
 
     fixture = report["fixtures"][0]
     assert fixture["fixture"] == "medication_exception_logic"
+    assert fixture["blocked_missing_class_code_terms"] == {"cyp3a4 inhibitors inducers": 1}
     assert fixture["projection_status_distribution"] == {
         "blocked_missing_class_code": 1,
         "projected": 7,

--- a/tests/unit/test_criterion_projection.py
+++ b/tests/unit/test_criterion_projection.py
@@ -235,3 +235,29 @@ def test_cyp3a4_inducer_inhibitor_class_remains_blocked_pending_safe_source():
     assert projections[0].terminology_status == "recognized_class_missing_safe_code"
     assert projections[0].review_required is True
     assert projections[0].resource is None
+
+
+@pytest.mark.parametrize(
+    ("mention_text", "normalized_term"),
+    [
+        ("agent targeting kras", "agent targeting kras"),
+        ("kras-targeted therapy", "kras targeted therapy"),
+    ],
+)
+def test_kras_targeted_class_terms_remain_blocked_pending_safe_source(mention_text: str, normalized_term: str):
+    mapper = CriterionProjectionMapper()
+    criterion = _make_criterion(
+        original_text=f"Has received previous treatment with {mention_text}",
+        value_text=mention_text,
+        entities=[Entity(text=mention_text, label="DRUG", start=36, end=36 + len(mention_text))],
+        allowance_text=None,
+    )
+
+    projections = mapper.project_criterion(criterion)
+
+    assert len(projections) == 1
+    assert projections[0].normalized_term == normalized_term
+    assert projections[0].projection_status == "blocked_missing_class_code"
+    assert projections[0].terminology_status == "recognized_class_missing_safe_code"
+    assert projections[0].review_required is True
+    assert projections[0].resource is None


### PR DESCRIPTION
## Summary
- surface blocked therapy-class terminology gap terms in curated corpus report output
- add fixture- and summary-level reporting for blocked missing class-code terms
- lock in regression coverage for KRAS-targeted and CYP3A4 class-gap cases that should remain safely blocked

## Motivation
The project roadmap explicitly calls out terminology gaps as the next priority area. This PR improves observability for that work by making the remaining blocked therapy-class concepts visible in the curated corpus report, instead of only showing aggregate counts.

That gives us a better way to:
- see which unresolved class concepts are still blocking projection
- distinguish coverage gaps from extraction failures
- prioritize safe terminology-expansion work with concrete corpus evidence

## Changes
- `app/scripts/curated_corpus_report.py`
  - aggregate `blocked_missing_class_code_terms` for each fixture
  - aggregate the same metric in the report summary
  - render those term counts in markdown output
- `tests/integration/test_curated_corpus_sweep.py`
  - verify summary-level blocked-term reporting
  - verify fixture-level blocked-term reporting
  - verify markdown rendering includes the blocked-term summary line
- `tests/unit/test_criterion_projection.py`
  - add regression coverage for KRAS-targeted class mentions remaining blocked pending a safe source concept/code
  - preserve the existing safe-block behavior for unresolved therapy-class concepts

## Test Plan
- [x] Unit tests pass: `./.ctm-dev/bin/python -m pytest tests/unit/test_criterion_projection.py -q`
- [x] Integration tests pass: `./.ctm-dev/bin/python -m pytest tests/integration/test_curated_corpus_sweep.py -q`
- [x] Manual output verification: `./.ctm-dev/bin/python -m app.scripts.curated_corpus_report --format json`
- [x] No intentional product-surface changes; this is reporting + regression coverage only

## Example
Summary output now surfaces blocked class-gap terms explicitly, e.g.:

```json
{"agent targeting kras": 1, "cyp3a4 inhibitors inducers": 3}
```

## Notes for Reviewers
- This is a focused observability/regression PR, not a terminology-expansion PR.
- The intent is to make follow-up terminology work easier to scope and validate without weakening the current safe-blocking behavior.
- I’d review `app/scripts/curated_corpus_report.py` first, then the integration and unit test additions.
