### PR TITLE
fix(ingestion): harden ctgov search contract handling

### DIFF
--- a/app/api/openapi.py
+++ b/app/api/openapi.py
@@ -36,6 +36,12 @@ VALIDATION_RESPONSE = _error_response(
     "nct_id: String should match pattern '^NCT\\d{8}$'",
     "validation_error",
 )
+EXTERNAL_VALIDATION_RESPONSE = _error_response(
+    400,
+    "External request validation error",
+    "ClinicalTrials.gov rejected the phase filter for this search request.",
+    "external_validation_error",
+)
 RATE_LIMIT_RESPONSE = _error_response(
     429,
     "Operational rate limit exceeded",
@@ -69,6 +75,10 @@ PROTECTED_OPERATIONAL_RESPONSES = {
     429: RATE_LIMIT_RESPONSE,
     500: INTERNAL_SERVER_ERROR_RESPONSE,
     503: SERVICE_UNAVAILABLE_RESPONSE,
+}
+SEARCH_OPERATIONAL_RESPONSES = {
+    400: EXTERNAL_VALIDATION_RESPONSE,
+    **PROTECTED_OPERATIONAL_RESPONSES,
 }
 PROTECTED_REVIEW_RESPONSES = {
     401: UNAUTHORIZED_RESPONSE,

--- a/app/api/routes/trials.py
+++ b/app/api/routes/trials.py
@@ -8,12 +8,14 @@ from sqlalchemy.orm import Query as SQLAlchemyQuery
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import add_request_log_context, rate_limit_dependency, require_api_key
+from app.api.errors import api_exception
 from app.api.openapi import (
     COMMON_ERROR_RESPONSES,
     PROTECTED_OPERATIONAL_RESPONSES,
     PROTECTED_READ_RESPONSES,
     PROTECTED_REVIEW_RESPONSES,
     READ_ERROR_RESPONSES,
+    SEARCH_OPERATIONAL_RESPONSES,
 )
 from app.api.schemas import (
     CriteriaListResponse,
@@ -41,7 +43,7 @@ from app.db.session import get_db
 from app.fhir.criterion_projection import CriterionProjectionMapper
 from app.fhir.mapper import FHIRMapper
 from app.fhir.models import ResearchStudy
-from app.ingestion.service import IngestionService
+from app.ingestion.service import ExternalServiceValidationError, IngestionService
 from app.models.database import ExtractedCriterion, FHIRResearchStudy, PipelineRun, Trial
 from app.time_utils import utc_now
 
@@ -98,7 +100,7 @@ def ingest_trial(
     "/trials/search-ingest",
     status_code=201,
     response_model=SearchIngestResponse,
-    responses=PROTECTED_OPERATIONAL_RESPONSES,
+    responses=SEARCH_OPERATIONAL_RESPONSES,
 )
 def search_and_ingest(
     payload: SearchIngestRequest,
@@ -107,13 +109,16 @@ def search_and_ingest(
     service: IngestionService = Depends(_get_ingestion_service),
 ):
     add_request_log_context(request)
-    results = service.search_and_ingest(
-        condition=payload.condition,
-        status=payload.status,
-        phase=payload.phase,
-        limit=payload.limit,
-        page_token=payload.page_token,
-    )
+    try:
+        results = service.search_and_ingest(
+            condition=payload.condition,
+            status=payload.status,
+            phase=payload.phase,
+            limit=payload.limit,
+            page_token=payload.page_token,
+        )
+    except ExternalServiceValidationError as exc:
+        raise api_exception(400, exc.detail, code="external_validation_error") from exc
     if isinstance(results, list):
         batch_results = results
         returned = len(results)

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class APIModel(BaseModel):
@@ -19,6 +19,22 @@ class SearchIngestRequest(APIModel):
     phase: str | None = None
     page_token: str | None = None
     limit: int = Field(default=25, ge=1, le=100)
+
+    @field_validator("condition", "status", "phase", mode="before")
+    @classmethod
+    def strip_optional_search_values(cls, value: str | None):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @model_validator(mode="after")
+    def validate_has_search_field(self):
+        if not (self.condition or self.status or self.phase):
+            raise ValueError("Provide at least one search field")
+        return self
 
 
 class CodedConceptUpdate(APIModel):

--- a/app/ingestion/ctgov_client.py
+++ b/app/ingestion/ctgov_client.py
@@ -8,6 +8,10 @@ from app.config import settings
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 
+def _phase_advanced_filter(phase: str) -> str:
+    return f"AREA[Phase]{phase}"
+
+
 @dataclass
 class SearchStudiesResult:
     studies: list[dict]
@@ -38,7 +42,7 @@ class CTGovClient:
         if status:
             params["filter.overallStatus"] = status
         if phase:
-            params["filter.phase"] = phase
+            params["filter.advanced"] = _phase_advanced_filter(phase)
         if page_token:
             params["pageToken"] = page_token
         payload = self._get_json(f"{self._base_url}/studies", params=params)

--- a/app/ingestion/service.py
+++ b/app/ingestion/service.py
@@ -106,6 +106,12 @@ class SearchIngestBatchResult:
     next_page_token: str | None = None
 
 
+class ExternalServiceValidationError(Exception):
+    def __init__(self, detail: str):
+        super().__init__(detail)
+        self.detail = detail
+
+
 class IngestionService:
     def __init__(self, db: Session, pipeline: ExtractionPipeline | None = None):
         self._db = db
@@ -261,9 +267,16 @@ class IngestionService:
         page_token: str | None = None,
     ) -> SearchIngestBatchResult:
         """Search ClinicalTrials.gov and ingest matching studies."""
-        search_result = self._client.search_studies(
-            condition=condition, status=status, phase=phase, limit=limit, page_token=page_token,
-        )
+        try:
+            search_result = self._client.search_studies(
+                condition=condition, status=status, phase=phase, limit=limit, page_token=page_token,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 400:
+                raise ExternalServiceValidationError(
+                    self._external_search_validation_message(exc, phase=phase)
+                ) from exc
+            raise
         if isinstance(search_result, list):
             studies = search_result
             total_count = None
@@ -321,6 +334,12 @@ class IngestionService:
         if isinstance(exc, SQLAlchemyError):
             return "Trial ingestion persistence failed"
         return "Trial ingestion failed"
+
+    def _external_search_validation_message(self, exc: httpx.HTTPStatusError, *, phase: str | None = None) -> str:
+        response_text = exc.response.text.lower()
+        if phase and ("filter.phase" in response_text or "phase" in response_text):
+            return "ClinicalTrials.gov rejected the phase filter for this search request."
+        return "ClinicalTrials.gov rejected this search request."
 
     def _content_hash_material(self, raw_json: dict) -> dict:
         protocol = raw_json.get("protocolSection", {})

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -58,7 +58,10 @@ export default async function PipelinePage({
       />
 
       {params.error ? (
-        <Panel title="Operation Error" eyebrow="Submit failed">
+        <Panel
+          title={params.condition || params.status || params.phase ? "Search Ingest Error" : "Operation Error"}
+          eyebrow={params.condition || params.status || params.phase ? "Search request failed" : "Submit failed"}
+        >
           <p className="text-sm leading-7 text-ember">{params.error}</p>
         </Panel>
       ) : null}

--- a/frontend/src/lib/api/openapi.json
+++ b/frontend/src/lib/api/openapi.json
@@ -139,6 +139,29 @@
       "CriterionCorrectionData": {
         "additionalProperties": false,
         "properties": {
+          "allowance_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowance Text"
+          },
+          "assay_context": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assay Context"
+          },
           "category": {
             "anyOf": [
               {
@@ -176,6 +199,54 @@
               }
             ],
             "title": "Confidence"
+          },
+          "disease_subtype": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disease Subtype"
+          },
+          "exception_entities": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exception Entities"
+          },
+          "exception_logic": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exception Logic"
+          },
+          "histology_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Histology Text"
           },
           "logic_group_id": {
             "anyOf": [
@@ -242,6 +313,17 @@
             ],
             "title": "Parse Status"
           },
+          "primary_semantic_category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Semantic Category"
+          },
           "raw_expression": {
             "anyOf": [
               {
@@ -252,6 +334,42 @@
               }
             ],
             "title": "Raw Expression"
+          },
+          "secondary_semantic_tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secondary Semantic Tags"
+          },
+          "specimen_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specimen Type"
+          },
+          "testing_modality": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Testing Modality"
           },
           "timeframe_operator": {
             "anyOf": [
@@ -349,9 +467,194 @@
         "title": "CriterionCorrectionData",
         "type": "object"
       },
+      "CriterionFHIRProjectionListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "breakdown_by_resource_type": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Breakdown By Resource Type",
+            "type": "object"
+          },
+          "breakdown_by_status": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Breakdown By Status",
+            "type": "object"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CriterionFHIRProjectionResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "breakdown_by_status",
+          "breakdown_by_resource_type"
+        ],
+        "title": "CriterionFHIRProjectionListResponse",
+        "type": "object"
+      },
+      "CriterionFHIRProjectionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "criterion_category": {
+            "title": "Criterion Category",
+            "type": "string"
+          },
+          "criterion_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Criterion Id"
+          },
+          "criterion_type": {
+            "title": "Criterion Type",
+            "type": "string"
+          },
+          "display": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display"
+          },
+          "mention_text": {
+            "title": "Mention Text",
+            "type": "string"
+          },
+          "normalized_term": {
+            "title": "Normalized Term",
+            "type": "string"
+          },
+          "projection_status": {
+            "title": "Projection Status",
+            "type": "string"
+          },
+          "resource": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource"
+          },
+          "resource_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Type"
+          },
+          "review_required": {
+            "title": "Review Required",
+            "type": "boolean"
+          },
+          "system": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "System"
+          },
+          "terminology_status": {
+            "title": "Terminology Status",
+            "type": "string"
+          },
+          "trial_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trial Id"
+          }
+        },
+        "required": [
+          "criterion_category",
+          "criterion_type",
+          "mention_text",
+          "normalized_term",
+          "projection_status",
+          "terminology_status",
+          "review_required"
+        ],
+        "title": "CriterionFHIRProjectionResponse",
+        "type": "object"
+      },
       "CriterionResponse": {
         "additionalProperties": false,
         "properties": {
+          "allowance_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowance Text"
+          },
+          "assay_context": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assay Context"
+          },
           "category": {
             "title": "Category",
             "type": "string"
@@ -367,6 +670,18 @@
             "title": "Confidence",
             "type": "number"
           },
+          "confidence_factors": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Factors"
+          },
           "created_at": {
             "anyOf": [
               {
@@ -378,6 +693,47 @@
               }
             ],
             "title": "Created At"
+          },
+          "disease_subtype": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disease Subtype"
+          },
+          "exception_entities": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Exception Entities",
+            "type": "array"
+          },
+          "exception_logic": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exception Logic"
+          },
+          "histology_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Histology Text"
           },
           "id": {
             "format": "uuid",
@@ -443,6 +799,17 @@
           "pipeline_version": {
             "title": "Pipeline Version",
             "type": "string"
+          },
+          "primary_semantic_category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Semantic Category"
           },
           "raw_expression": {
             "anyOf": [
@@ -514,6 +881,57 @@
               }
             ],
             "title": "Reviewed By"
+          },
+          "secondary_semantic_tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Secondary Semantic Tags",
+            "type": "array"
+          },
+          "source_clause_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Clause Text"
+          },
+          "source_sentence": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Sentence"
+          },
+          "specimen_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specimen Type"
+          },
+          "testing_modality": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Testing Modality"
           },
           "timeframe_operator": {
             "anyOf": [
@@ -1336,6 +1754,17 @@
             ],
             "title": "Birth Date"
           },
+          "can_consent": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Consent"
+          },
           "city": {
             "anyOf": [
               {
@@ -1346,6 +1775,17 @@
               }
             ],
             "title": "City"
+          },
+          "claustrophobic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Claustrophobic"
           },
           "conditions": {
             "items": {
@@ -1436,6 +1876,50 @@
             "title": "Medications",
             "type": "array"
           },
+          "motion_intolerant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motion Intolerant"
+          },
+          "mr_device_present": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mr Device Present"
+          },
+          "pregnant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pregnant"
+          },
+          "protocol_compliant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol Compliant"
+          },
           "sex": {
             "anyOf": [
               {
@@ -1497,6 +1981,17 @@
             ],
             "title": "Birth Date"
           },
+          "can_consent": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Consent"
+          },
           "city": {
             "anyOf": [
               {
@@ -1507,6 +2002,17 @@
               }
             ],
             "title": "City"
+          },
+          "claustrophobic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Claustrophobic"
           },
           "conditions": {
             "items": {
@@ -1611,6 +2117,50 @@
             },
             "title": "Medications",
             "type": "array"
+          },
+          "motion_intolerant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motion Intolerant"
+          },
+          "mr_device_present": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mr Device Present"
+          },
+          "pregnant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pregnant"
+          },
+          "protocol_compliant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol Compliant"
           },
           "sex": {
             "anyOf": [
@@ -1881,6 +2431,17 @@
             ],
             "title": "Birth Date"
           },
+          "can_consent": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Consent"
+          },
           "city": {
             "anyOf": [
               {
@@ -1891,6 +2452,17 @@
               }
             ],
             "title": "City"
+          },
+          "claustrophobic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Claustrophobic"
           },
           "country": {
             "anyOf": [
@@ -1974,6 +2546,50 @@
               }
             ],
             "title": "Longitude"
+          },
+          "motion_intolerant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motion Intolerant"
+          },
+          "mr_device_present": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mr Device Present"
+          },
+          "pregnant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pregnant"
+          },
+          "protocol_compliant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol Compliant"
           },
           "sex": {
             "anyOf": [
@@ -2139,6 +2755,17 @@
             ],
             "title": "Birth Date"
           },
+          "can_consent": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Consent"
+          },
           "city": {
             "anyOf": [
               {
@@ -2149,6 +2776,17 @@
               }
             ],
             "title": "City"
+          },
+          "claustrophobic": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Claustrophobic"
           },
           "conditions": {
             "anyOf": [
@@ -2259,6 +2897,50 @@
               }
             ],
             "title": "Medications"
+          },
+          "motion_intolerant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Motion Intolerant"
+          },
+          "mr_device_present": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mr Device Present"
+          },
+          "pregnant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pregnant"
+          },
+          "protocol_compliant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol Compliant"
           },
           "sex": {
             "anyOf": [
@@ -3175,6 +3857,76 @@
           }
         },
         "summary": "Get Criterion"
+      }
+    },
+    "/api/v1/criteria/{criterion_id}/fhir-projections": {
+      "get": {
+        "operationId": "get_criterion_fhir_projections_api_v1_criteria__criterion_id__fhir_projections_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "criterion_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Criterion Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CriterionFHIRProjectionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "detail": "Trial not found",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Requested resource was not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "internal_server_error",
+                  "detail": "Internal server error",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unhandled server error"
+          }
+        },
+        "summary": "Get Criterion Fhir Projections"
       }
     },
     "/api/v1/criteria/{criterion_id}/review": {
@@ -4725,6 +5477,21 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "external_validation_error",
+                  "detail": "ClinicalTrials.gov rejected the phase filter for this search request.",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "External request validation error"
+          },
           "401": {
             "content": {
               "application/json": {
@@ -5086,6 +5853,76 @@
           }
         },
         "summary": "Get Trial Fhir"
+      }
+    },
+    "/api/v1/trials/{trial_id}/fhir-projections": {
+      "get": {
+        "operationId": "get_trial_fhir_projections_api_v1_trials__trial_id__fhir_projections_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trial_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Trial Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CriterionFHIRProjectionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "detail": "Trial not found",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Requested resource was not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "internal_server_error",
+                  "detail": "Internal server error",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unhandled server error"
+          }
+        },
+        "summary": "Get Trial Fhir Projections"
       }
     },
     "/api/v1/trials/{trial_id}/re-extract": {

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 from app.config import settings
 from app.db.session import get_db
-from app.ingestion.service import SearchIngestBatchResult, SearchIngestTrialResult
+from app.ingestion.service import ExternalServiceValidationError, SearchIngestBatchResult, SearchIngestTrialResult
 from app.main import app
 from app.models.database import ExtractedCriterion, PipelineRun, Trial
 from app.scripts.seed import sync_coding_lookups
@@ -443,6 +443,28 @@ class TestSearchIngestEndpoint:
         assert data["trials"][2]["error_message"] == "boom"
         assert data["trials"][3]["nct_id"] is None
         assert data["trials"][3]["error_message"] == "Search result missing NCT ID"
+
+    def test_search_ingest_maps_external_validation_failures_to_bad_request(self, client):
+        with patch(
+            "app.api.routes.trials.IngestionService.search_and_ingest",
+            side_effect=ExternalServiceValidationError(
+                "ClinicalTrials.gov rejected the phase filter for this search request."
+            ),
+        ):
+            response = client.post(
+                "/api/v1/trials/search-ingest",
+                json={"condition": "breast cancer", "status": "RECRUITING", "phase": "PHASE2", "limit": 2},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "ClinicalTrials.gov rejected the phase filter for this search request."
+        assert response.json()["code"] == "external_validation_error"
+
+    def test_search_ingest_requires_at_least_one_search_field(self, client):
+        response = client.post("/api/v1/trials/search-ingest", json={"limit": 2})
+
+        assert response.status_code == 422
+        assert "at least one search field" in json.dumps(response.json()).lower()
 
 
 @pytestmark_docker

--- a/tests/unit/test_ctgov_client.py
+++ b/tests/unit/test_ctgov_client.py
@@ -102,3 +102,24 @@ class TestSearchStudies:
         assert kwargs["params"]["pageSize"] == 5
         assert kwargs["params"]["pageToken"] == "cursor-1"
         assert kwargs["params"]["countTotal"] == "true"
+
+    def test_search_studies_translates_phase_to_supported_advanced_filter(self, client):
+        client._client.get = Mock(
+            return_value=_response(
+                200,
+                json_body={
+                    "studies": [],
+                    "totalCount": 0,
+                },
+            )
+        )
+
+        client.search_studies(condition="breast cancer", status="RECRUITING", phase="PHASE2", limit=2)
+
+        client._client.get.assert_called_once()
+        _, kwargs = client._client.get.call_args
+        params = kwargs["params"]
+        assert params["query.cond"] == "breast cancer"
+        assert params["filter.overallStatus"] == "RECRUITING"
+        assert params["filter.advanced"] == "AREA[Phase]PHASE2"
+        assert "filter.phase" not in params


### PR DESCRIPTION
## Bug Description
Batch search-ingest could fail with an internal error for common phase-filtered searches such as:
- condition: `breast cancer`
- status: `RECRUITING`
- phase: `PHASE2`

Instead of returning an actionable request error, the app could surface a generic failure after ClinicalTrials.gov rejected the upstream query.

## Root Cause
The backend encoded phase filtering using an unsupported CT.gov v2 parameter:
- `filter.phase=PHASE2`

That caused an upstream `400 Bad Request`, which then propagated through the stack as a broken operational path.

There were also two contract gaps around that failure mode:
- search requests were not validated symmetrically on the backend
- the API/OpenAPI contract did not clearly expose the external validation error response for `search-ingest`

## Fix
- translate phase filtering to the supported CT.gov advanced filter form:
  - `filter.advanced=AREA[Phase]PHASE2`
- map upstream CT.gov search-contract `400` failures to a client-facing `400 external_validation_error`
- require at least one of `condition`, `status`, or `phase` in the backend request schema
- trim backend search fields before validation to match frontend normalization behavior
- scope the new `400` response contract to `/trials/search-ingest` only
- regenerate the frontend OpenAPI artifact
- make the pipeline page error panel more specific for search-ingest failures

## How to Verify
1. Trigger `POST /api/v1/trials/search-ingest` with `condition=breast cancer`, `status=RECRUITING`, `phase=PHASE2`.
2. Confirm the backend no longer sends `filter.phase` upstream.
3. Confirm CT.gov phase filtering uses the supported advanced filter path.
4. Confirm upstream contract failures return `400` with code `external_validation_error`, not `500`.
5. Confirm the pipeline page shows a search-specific error title instead of a generic operation label.

## Test Plan
- [x] Added unit regression coverage for CT.gov phase parameter translation
- [x] Added API regression coverage for search-ingest external validation failures
- [x] Added API regression coverage for requiring at least one search field
- [x] Backend tests pass:
  - `./.ctm-dev/bin/python -m pytest tests/unit/test_ctgov_client.py -q`
  - `./.ctm-dev/bin/python -m pytest tests/integration/test_api_endpoints.py -q -k 'search_ingest_reports_attempted_skipped_and_failed or search_ingest_maps_external_validation_failures_to_bad_request or search_ingest_requires_at_least_one_search_field'`
- [x] Frontend typecheck passes: `cd frontend && npm run typecheck`
- [x] Frontend OpenAPI artifact regenerated

## Risk Assessment
**Medium** — touches backend request construction, error mapping, and the generated API contract, but remains tightly scoped to the search-ingest path.

## Notes for Reviewers
- This PR intentionally focuses on the **search contract boundary**, not on broader ingestion behavior.
- The new external validation error is scoped to `/trials/search-ingest` only.
- Review order:
  1. `app/ingestion/ctgov_client.py`
  2. `app/ingestion/service.py`
  3. `app/api/routes/trials.py` + `app/api/schemas.py`
  4. tests and regenerated OpenAPI artifact
