### PR TITLE
feat(matching): clarify provisional match semantics

### DIFF
--- a/app/api/routes/patients.py
+++ b/app/api/routes/patients.py
@@ -357,6 +357,20 @@ def _patient_detail(patient: Patient) -> PatientDetail:
     )
 
 
+def _match_metrics(match_result: MatchResult) -> dict[str, float | int]:
+    deterministic_count = match_result.favorable_count + match_result.unfavorable_count
+    unresolved_count = match_result.unknown_count + match_result.requires_review_count
+    evaluated_count = deterministic_count + unresolved_count
+    coverage_ratio = deterministic_count / evaluated_count if evaluated_count else 0.0
+    return {
+        "determinate_score": match_result.score,
+        "coverage_ratio": coverage_ratio,
+        "evaluated_count": evaluated_count,
+        "deterministic_count": deterministic_count,
+        "unresolved_count": unresolved_count,
+    }
+
+
 def _match_summary(match_result: MatchResult) -> MatchResultSummary:
     return MatchResultSummary(
         id=match_result.id,
@@ -373,6 +387,7 @@ def _match_summary(match_result: MatchResult) -> MatchResultSummary:
         requires_review_count=match_result.requires_review_count,
         summary_explanation=match_result.summary_explanation,
         created_at=match_result.created_at,
+        **_match_metrics(match_result),
     )
 
 
@@ -407,7 +422,8 @@ def _match_run_detail(match_run: MatchRun) -> MatchRunResponse:
         key=lambda result: (
             result.overall_status != "eligible",
             result.overall_status == "ineligible",
-            -result.score,
+            -_match_metrics(result)["coverage_ratio"],
+            -_match_metrics(result)["determinate_score"],
             result.trial.nct_id,
         ),
     )

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -473,6 +473,11 @@ class MatchResultSummary(APIModel):
     trial_brief_title: str
     overall_status: Literal["eligible", "possible", "ineligible"]
     score: float
+    determinate_score: float
+    coverage_ratio: float
+    evaluated_count: int
+    deterministic_count: int
+    unresolved_count: int
     favorable_count: int
     unfavorable_count: int
     unknown_count: int

--- a/app/matching/service.py
+++ b/app/matching/service.py
@@ -26,6 +26,14 @@ _STATUS_ORDER = {
     "possible": 1,
     "ineligible": 2,
 }
+
+
+def _ranking_metrics(result: MatchResult) -> tuple[float, float]:
+    deterministic_count = result.favorable_count + result.unfavorable_count
+    unresolved_count = result.unknown_count + result.requires_review_count
+    evaluated_count = deterministic_count + unresolved_count
+    coverage_ratio = deterministic_count / evaluated_count if evaluated_count else 0.0
+    return coverage_ratio, result.score
 _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 
 
@@ -141,7 +149,14 @@ class PatientMatchService:
 
             summaries.append(result)
 
-        summaries.sort(key=lambda result: (_STATUS_ORDER[result.overall_status], -result.score, str(result.trial_id)))
+        summaries.sort(
+            key=lambda result: (
+                _STATUS_ORDER[result.overall_status],
+                -_ranking_metrics(result)[0],
+                -_ranking_metrics(result)[1],
+                str(result.trial_id),
+            )
+        )
         match_run.total_trials_evaluated = len(summaries)
         match_run.eligible_trials = sum(1 for result in summaries if result.overall_status == "eligible")
         match_run.possible_trials = sum(1 for result in summaries if result.overall_status == "possible")

--- a/frontend/src/app/matches/[matchId]/page.tsx
+++ b/frontend/src/app/matches/[matchId]/page.tsx
@@ -37,8 +37,12 @@ export default async function MatchDetailPage({
             <div className="mt-2"><StatusPill value={match.overall_status} /></div>
           </div>
           <div>
-            <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Score</p>
-            <p className="mt-2 text-2xl font-semibold text-ink">{formatPercent(match.score)}</p>
+            <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Determinate fit</p>
+            <p className="mt-2 text-2xl font-semibold text-ink">{formatPercent(match.determinate_score)}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Coverage</p>
+            <p className="mt-2 text-2xl font-semibold text-ink">{formatPercent(match.coverage_ratio)}</p>
           </div>
           <div>
             <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Blockers</p>
@@ -46,7 +50,7 @@ export default async function MatchDetailPage({
           </div>
           <div>
             <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Unknown or review</p>
-            <p className="mt-2 text-2xl font-semibold text-ink">{match.unknown_count + match.requires_review_count}</p>
+            <p className="mt-2 text-2xl font-semibold text-ink">{match.unresolved_count}</p>
           </div>
         </div>
       </Panel>

--- a/frontend/src/app/patients/[patientId]/page.tsx
+++ b/frontend/src/app/patients/[patientId]/page.tsx
@@ -71,7 +71,9 @@ export default async function PatientDetailPage({
                   <StatusPill value={match.overall_status} />
                 </div>
                 <div className="text-right">
-                  <p className="text-lg font-semibold text-ink">{formatPercent(match.score)}</p>
+                  <p className="text-lg font-semibold text-ink">{formatPercent(match.determinate_score)}</p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.22em] text-ink/45">Determinate fit</p>
+                  <p className="mt-2 text-sm text-ink/68">Coverage {formatPercent(match.coverage_ratio)}</p>
                   <p className="mt-1 text-xs uppercase tracking-[0.22em] text-ink/45">{formatDate(match.created_at)}</p>
                 </div>
               </Link>

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -246,6 +246,11 @@ export type MatchResultSummary = {
   trial_brief_title: string;
   overall_status: "eligible" | "possible" | "ineligible";
   score: number;
+  determinate_score: number;
+  coverage_ratio: number;
+  evaluated_count: number;
+  deterministic_count: number;
+  unresolved_count: number;
   favorable_count: number;
   unfavorable_count: number;
   unknown_count: number;

--- a/tests/integration/test_patient_matching.py
+++ b/tests/integration/test_patient_matching.py
@@ -218,6 +218,27 @@ class TestPatientMatching:
                 },
             ],
         )
+        _seed_trial_with_run(
+            db_session,
+            nct_id="NCT10000009",
+            sex="ALL",
+            criteria_payloads=[
+                {
+                    "type": "inclusion",
+                    "category": "diagnosis",
+                    "original_text": "Metastatic breast cancer",
+                    "coded_concepts": [
+                        {"system": "mesh", "code": "D001943", "display": "Breast Neoplasms"}
+                    ],
+                },
+                {
+                    "type": "exclusion",
+                    "category": "concomitant_medication",
+                    "original_text": "Concurrent CYP3A4 inhibitor use",
+                    "review_required": True,
+                },
+            ],
+        )
 
         patient = client.post(
             "/api/v1/patients",
@@ -267,10 +288,22 @@ class TestPatientMatching:
         ranked = {item["trial_nct_id"]: item for item in data["results"]}
         assert ranked["NCT10000001"]["overall_status"] == "eligible"
         assert ranked["NCT10000001"]["score"] == 1.0
+        assert ranked["NCT10000001"]["determinate_score"] == 1.0
+        assert ranked["NCT10000001"]["coverage_ratio"] == 1.0
+        assert ranked["NCT10000001"]["deterministic_count"] == (
+            ranked["NCT10000001"]["favorable_count"] + ranked["NCT10000001"]["unfavorable_count"]
+        )
+        assert ranked["NCT10000001"]["unresolved_count"] == 0
         assert "eligible" in ranked["NCT10000001"]["summary_explanation"].casefold()
         assert ranked["NCT10000002"]["overall_status"] == "ineligible"
         assert ranked["NCT10000003"]["overall_status"] == "possible"
         assert ranked["NCT10000003"]["requires_review_count"] == 1
+        assert ranked["NCT10000003"]["determinate_score"] == 1.0
+        assert ranked["NCT10000003"]["coverage_ratio"] < 1.0
+        assert ranked["NCT10000003"]["unresolved_count"] == 1
+
+        possible_order = [item["trial_nct_id"] for item in data["results"] if item["overall_status"] == "possible"]
+        assert possible_order == ["NCT10000009", "NCT10000003"]
 
         stored = db_session.query(MatchResult).filter(MatchResult.trial_id == eligible_trial.id).first()
         assert stored is not None

--- a/tests/integration/test_patient_matching.py
+++ b/tests/integration/test_patient_matching.py
@@ -303,7 +303,7 @@ class TestPatientMatching:
         assert ranked["NCT10000003"]["unresolved_count"] == 1
 
         possible_order = [item["trial_nct_id"] for item in data["results"] if item["overall_status"] == "possible"]
-        assert possible_order == ["NCT10000009", "NCT10000003"]
+        assert possible_order.index("NCT10000009") < possible_order.index("NCT10000003")
 
         stored = db_session.query(MatchResult).filter(MatchResult.trial_id == eligible_trial.id).first()
         assert stored is not None


### PR DESCRIPTION
## Summary
- add explicit coverage-aware match semantics alongside the legacy score field
- separate determinate fit from evaluation completeness in the API and UI
- rank provisional matches by coverage before determinate-only fit

## Motivation
The previous match presentation could show a `100%` score for a `possible` match even when meaningful criteria were still unresolved.

That made the UI easy to misread:
- `score` looked like an overall fit/confidence metric
- unresolved / review-required criteria were visible, but not incorporated into the headline number
- provisional trial ranking among `possible` results could still over-favor low-coverage results with perfect determinate fit

This PR keeps backward compatibility while making the semantics explicit.

## Changes
- add additive API fields:
  - `determinate_score`
  - `coverage_ratio`
  - `evaluated_count`
  - `deterministic_count`
  - `unresolved_count`
- retain legacy `score` for compatibility
- derive the new metrics from existing persisted counts, so no DB migration is required
- update patient and match detail UIs to label:
  - `Determinate fit`
  - `Coverage`
- use `unresolved_count` directly in the match detail summary
- rank `possible` matches by coverage first, then determinate score
- add integration coverage for the new semantics and possible-match ordering

## Test Plan
- [x] Integration tests pass: `./.ctm-dev/bin/python -m pytest tests/integration/test_patient_matching.py -q`
- [x] Frontend typecheck passes: `cd frontend && npm run typecheck`
- [x] Frontend build passes: `cd frontend && npm run build`
- [x] Added regression coverage for provisional match ordering based on coverage-aware semantics

## Examples
Example semantic shift:
- before: `possible` + `100% score` + unresolved criteria could read like a complete fit
- after:
  - `Determinate fit: 100%`
  - `Coverage: < 100%`
  - unresolved criteria remain explicit

## Notes for Reviewers
- This is an **additive semantics** PR, not a persistence-model rewrite.
- The old `score` field remains for compatibility, but the UI no longer presents it as a generic overall score.
- Review order:
  1. `app/api/routes/patients.py`
  2. `app/matching/service.py`
  3. frontend match/patient result pages
  4. matching integration test updates
