### PR TITLE
feat: add evidence-grounded match explanation cards

### DIFF
--- a/app/api/routes/patients.py
+++ b/app/api/routes/patients.py
@@ -7,6 +7,8 @@ from app.api.dependencies import require_api_key
 from app.api.openapi import PROTECTED_MUTATION_RESPONSES, PROTECTED_RESOURCE_RESPONSES
 from app.api.schemas import (
     MatchCriterionResultResponse,
+    MatchExplanationItemResponse,
+    MatchExplanationResponse,
     MatchResultDetail,
     MatchResultListResponse,
     MatchResultSummary,
@@ -395,30 +397,113 @@ def _match_summary(match_result: MatchResult) -> MatchResultSummary:
     )
 
 
+def _build_match_criterion_response(criterion) -> MatchCriterionResultResponse:
+    state, state_reason = criterion_state_from_match_result_criterion(criterion)
+    return MatchCriterionResultResponse(
+        id=criterion.id,
+        criterion_id=criterion.criterion_id,
+        pipeline_run_id=criterion.pipeline_run_id,
+        source_type=criterion.source_type,
+        source_label=criterion.source_label,
+        criterion_type=criterion.criterion_type,
+        category=criterion.category,
+        criterion_text=criterion.criterion_text,
+        outcome=criterion.outcome,
+        state=state,
+        state_reason=state_reason,
+        explanation_text=criterion.explanation_text,
+        explanation_type=criterion.explanation_type,
+        evidence_payload=criterion.evidence_payload,
+        created_at=criterion.created_at,
+    )
+
+
+def _explanation_label_for_category(category: str) -> str:
+    return category.replace("_", " ").title()
+
+
+def _first_scalar_evidence_value(value):
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, dict):
+        preferred_keys = (
+            "source_snippet",
+            "description",
+            "display",
+            "value_text",
+            "criterion_value_text",
+            "review_reason",
+            "required_sex",
+            "patient_sex",
+        )
+        for key in preferred_keys:
+            if key in value:
+                found = _first_scalar_evidence_value(value[key])
+                if found:
+                    return found
+        for nested_value in value.values():
+            found = _first_scalar_evidence_value(nested_value)
+            if found:
+                return found
+        return None
+    if isinstance(value, list):
+        for item in value:
+            found = _first_scalar_evidence_value(item)
+            if found:
+                return found
+    return None
+
+
+def _source_snippet_for_criterion(criterion) -> str | None:
+    if not isinstance(criterion.evidence_payload, dict):
+        return None
+    explicit_snippet = criterion.evidence_payload.get("source_snippet") or criterion.evidence_payload.get("source_text")
+    if isinstance(explicit_snippet, str) and explicit_snippet.strip():
+        return explicit_snippet.strip()
+    return None
+
+
+def _build_match_explanation_item(criterion) -> MatchExplanationItemResponse:
+    state, _ = criterion_state_from_match_result_criterion(criterion)
+    return MatchExplanationItemResponse(
+        label=_explanation_label_for_category(criterion.category),
+        category=criterion.category,
+        criterion_text=criterion.criterion_text,
+        outcome=criterion.outcome,
+        state=state,
+        explanation_text=criterion.explanation_text,
+        source_snippet=_source_snippet_for_criterion(criterion),
+        evidence_payload=criterion.evidence_payload,
+    )
+
+
+def _build_match_explanation(criteria) -> MatchExplanationResponse:
+    explanation = MatchExplanationResponse()
+    for criterion in criteria:
+        item = _build_match_explanation_item(criterion)
+        state, _ = criterion_state_from_match_result_criterion(criterion)
+
+        if criterion.outcome in {"matched", "not_triggered"}:
+            explanation.matched.append(item)
+        elif criterion.outcome in {"not_matched", "triggered"}:
+            explanation.blockers.append(item)
+
+        if criterion.outcome in {"unknown", "requires_review"} or state != "structured_safe":
+            explanation.review_required.append(item)
+    return explanation
+
+
 def _match_detail(match_result: MatchResult) -> MatchResultDetail:
     criteria = sorted(match_result.criteria, key=lambda criterion: (criterion.created_at, str(criterion.id)))
     return MatchResultDetail(
         **_match_summary(match_result).model_dump(),
-        criteria=[
-            MatchCriterionResultResponse(
-                id=criterion.id,
-                criterion_id=criterion.criterion_id,
-                pipeline_run_id=criterion.pipeline_run_id,
-                source_type=criterion.source_type,
-                source_label=criterion.source_label,
-                criterion_type=criterion.criterion_type,
-                category=criterion.category,
-                criterion_text=criterion.criterion_text,
-                outcome=criterion.outcome,
-                state=criterion_state_from_match_result_criterion(criterion)[0],
-                state_reason=criterion_state_from_match_result_criterion(criterion)[1],
-                explanation_text=criterion.explanation_text,
-                explanation_type=criterion.explanation_type,
-                evidence_payload=criterion.evidence_payload,
-                created_at=criterion.created_at,
-            )
-            for criterion in criteria
-        ],
+        criteria=[_build_match_criterion_response(criterion) for criterion in criteria],
+        explanation=_build_match_explanation(criteria),
     )
 
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -492,6 +492,23 @@ class MatchCriterionResultResponse(APIModel):
     created_at: datetime | None = None
 
 
+class MatchExplanationItemResponse(APIModel):
+    label: str
+    category: str
+    criterion_text: str
+    outcome: CriterionMatchOutcome
+    state: ConfidenceState
+    explanation_text: str | None = None
+    source_snippet: str | None = None
+    evidence_payload: dict[str, Any] | None = None
+
+
+class MatchExplanationResponse(APIModel):
+    matched: list[MatchExplanationItemResponse] = Field(default_factory=list)
+    blockers: list[MatchExplanationItemResponse] = Field(default_factory=list)
+    review_required: list[MatchExplanationItemResponse] = Field(default_factory=list)
+
+
 class MatchResultSummary(APIModel):
     id: UUID
     match_run_id: UUID
@@ -518,6 +535,7 @@ class MatchResultSummary(APIModel):
 
 class MatchResultDetail(MatchResultSummary):
     criteria: list[MatchCriterionResultResponse] = Field(default_factory=list)
+    explanation: MatchExplanationResponse = Field(default_factory=MatchExplanationResponse)
 
 
 class MatchRunResponse(APIModel):

--- a/frontend/src/app/matches/[matchId]/page.tsx
+++ b/frontend/src/app/matches/[matchId]/page.tsx
@@ -1,6 +1,7 @@
 import { StructuredDataView } from "@/components/structured-data-view";
 import Link from "next/link";
 
+import { MatchExplanationCard } from "@/components/match-explanation-card";
 import { PageHeader } from "@/components/page-header";
 import { Panel } from "@/components/panel";
 import { StatusPill } from "@/components/status-pill";
@@ -60,31 +61,59 @@ export default async function MatchDetailPage({
         </div>
       </Panel>
 
-      <div className="grid gap-4">
-        {match.criteria.map((criterion) => (
-          <article key={criterion.id} className="rounded-[30px] border border-ink/10 bg-white/75 p-6 shadow-card">
-            <div className="mb-4 flex flex-wrap items-center gap-3">
-              <StatusPill value={criterion.outcome} />
-              <StatusPill value={criterion.state} />
-              <span className="text-xs uppercase tracking-[0.24em] text-ink/45">{criterion.category}</span>
-              <span className="text-xs uppercase tracking-[0.24em] text-ink/45">{criterion.source_type}</span>
-            </div>
-            <p className="text-base font-semibold text-ink">{criterion.criterion_text}</p>
-            {criterion.state_reason ? (
-              <p className="mt-2 text-xs uppercase tracking-[0.18em] text-ink/45">{criterion.state_reason.replaceAll("_", " ")}</p>
-            ) : null}
-            <p className="mt-3 text-sm leading-7 text-ink/72">{criterion.explanation_text}</p>
-            {criterion.evidence_payload ? (
-              <details className="mt-4 rounded-2xl bg-sand/65 p-4">
-                <summary className="cursor-pointer text-sm font-semibold text-ink">Structured evidence</summary>
-                <div className="mt-4">
-                  <StructuredDataView data={criterion.evidence_payload} emptyLabel="No structured evidence payload is available." />
-                </div>
-              </details>
-            ) : null}
-          </article>
-        ))}
-      </div>
+      <Panel title="Evidence-Grounded Explanation" eyebrow="Grouped eligibility rationale">
+        <p className="text-sm leading-7 text-ink/72">
+          These cards summarize why the trial matched, what blocked eligibility, and which criteria still need review.
+        </p>
+        <div className="mt-6 grid gap-4 xl:grid-cols-3">
+          <MatchExplanationCard
+            title="Matched criteria"
+            eyebrow="Supports fit"
+            items={match.explanation.matched}
+            emptyMessage="No matched supporting criteria were surfaced for this result."
+          />
+          <MatchExplanationCard
+            title="Blockers"
+            eyebrow="Why this may be ineligible"
+            items={match.explanation.blockers}
+            emptyMessage="No blocking criteria were recorded for this result."
+          />
+          <MatchExplanationCard
+            title="Needs review"
+            eyebrow="Unresolved criteria"
+            items={match.explanation.review_required}
+            emptyMessage="No unresolved or review-required criteria remain for this result."
+          />
+        </div>
+      </Panel>
+
+      <Panel title="Criterion Breakdown" eyebrow="Raw persisted criterion results">
+        <div className="grid gap-4">
+          {match.criteria.map((criterion) => (
+            <article key={criterion.id} className="rounded-[30px] border border-ink/10 bg-white/75 p-6 shadow-card">
+              <div className="mb-4 flex flex-wrap items-center gap-3">
+                <StatusPill value={criterion.outcome} />
+                <StatusPill value={criterion.state} />
+                <span className="text-xs uppercase tracking-[0.24em] text-ink/45">{criterion.category}</span>
+                <span className="text-xs uppercase tracking-[0.24em] text-ink/45">{criterion.source_type}</span>
+              </div>
+              <p className="text-base font-semibold text-ink">{criterion.criterion_text}</p>
+              {criterion.state_reason ? (
+                <p className="mt-2 text-xs uppercase tracking-[0.18em] text-ink/45">{criterion.state_reason.replaceAll("_", " ")}</p>
+              ) : null}
+              <p className="mt-3 text-sm leading-7 text-ink/72">{criterion.explanation_text}</p>
+              {criterion.evidence_payload ? (
+                <details className="mt-4 rounded-2xl bg-sand/65 p-4">
+                  <summary className="cursor-pointer text-sm font-semibold text-ink">Structured evidence</summary>
+                  <div className="mt-4">
+                    <StructuredDataView data={criterion.evidence_payload} emptyLabel="No structured evidence payload is available." />
+                  </div>
+                </details>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </Panel>
     </>
   );
 }

--- a/frontend/src/components/match-explanation-card.tsx
+++ b/frontend/src/components/match-explanation-card.tsx
@@ -1,0 +1,50 @@
+import { StatusPill } from "@/components/status-pill";
+import type { MatchExplanationItem } from "@/lib/api/types";
+
+export function MatchExplanationCard({
+  title,
+  eyebrow,
+  emptyMessage,
+  items
+}: {
+  title: string;
+  eyebrow: string;
+  emptyMessage: string;
+  items: MatchExplanationItem[];
+}) {
+  return (
+    <article className="rounded-[30px] border border-ink/10 bg-white/75 p-6 shadow-card">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-tide">{eyebrow}</p>
+          <h3 className="mt-2 text-lg font-semibold text-ink">{title}</h3>
+        </div>
+        <p className="text-sm font-semibold text-ink/55">{items.length}</p>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-sm leading-7 text-ink/65">{emptyMessage}</p>
+      ) : (
+        <div className="grid gap-4">
+          {items.map((item, index) => (
+            <div key={`${item.category}-${item.outcome}-${index}`} className="rounded-3xl border border-ink/8 bg-sand/55 p-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill value={item.outcome} />
+                <StatusPill value={item.state} />
+                <span className="text-xs uppercase tracking-[0.22em] text-ink/45">{item.label}</span>
+              </div>
+              <p className="mt-3 text-sm font-semibold text-ink">{item.criterion_text}</p>
+              <p className="mt-2 text-sm leading-7 text-ink/72">{item.explanation_text ?? item.criterion_text}</p>
+              <div className="mt-3 rounded-2xl bg-white/70 px-4 py-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-ink/45">Evidence reference</p>
+                <p className="mt-2 text-sm leading-7 text-ink/72">
+                  {item.source_snippet ?? "No direct evidence snippet captured for this criterion yet."}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/lib/api/openapi.json
+++ b/frontend/src/lib/api/openapi.json
@@ -1338,6 +1338,116 @@
         "title": "MatchCriterionResultResponse",
         "type": "object"
       },
+      "MatchExplanationItemResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "criterion_text": {
+            "title": "Criterion Text",
+            "type": "string"
+          },
+          "evidence_payload": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence Payload"
+          },
+          "explanation_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanation Text"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "outcome": {
+            "enum": [
+              "matched",
+              "not_matched",
+              "unknown",
+              "requires_review",
+              "not_triggered",
+              "triggered"
+            ],
+            "title": "Outcome",
+            "type": "string"
+          },
+          "source_snippet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Snippet"
+          },
+          "state": {
+            "enum": [
+              "structured_safe",
+              "structured_low_confidence",
+              "review_required",
+              "blocked_unsupported"
+            ],
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "category",
+          "criterion_text",
+          "outcome",
+          "state"
+        ],
+        "title": "MatchExplanationItemResponse",
+        "type": "object"
+      },
+      "MatchExplanationResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "blockers": {
+            "items": {
+              "$ref": "#/components/schemas/MatchExplanationItemResponse"
+            },
+            "title": "Blockers",
+            "type": "array"
+          },
+          "matched": {
+            "items": {
+              "$ref": "#/components/schemas/MatchExplanationItemResponse"
+            },
+            "title": "Matched",
+            "type": "array"
+          },
+          "review_required": {
+            "items": {
+              "$ref": "#/components/schemas/MatchExplanationItemResponse"
+            },
+            "title": "Review Required",
+            "type": "array"
+          }
+        },
+        "title": "MatchExplanationResponse",
+        "type": "object"
+      },
       "MatchResultDetail": {
         "additionalProperties": false,
         "properties": {
@@ -1375,6 +1485,9 @@
           "evaluated_count": {
             "title": "Evaluated Count",
             "type": "integer"
+          },
+          "explanation": {
+            "$ref": "#/components/schemas/MatchExplanationResponse"
           },
           "favorable_count": {
             "title": "Favorable Count",

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -287,8 +287,25 @@ export type MatchCriterionResult = {
   created_at?: string | null;
 };
 
+export type MatchExplanationItem = {
+  label: string;
+  category: string;
+  criterion_text: string;
+  outcome: "matched" | "not_matched" | "unknown" | "requires_review" | "not_triggered" | "triggered";
+  state: MatchConfidenceState;
+  explanation_text?: string | null;
+  source_snippet?: string | null;
+  evidence_payload?: Record<string, unknown> | null;
+};
+export type MatchExplanation = {
+  matched: MatchExplanationItem[];
+  blockers: MatchExplanationItem[];
+  review_required: MatchExplanationItem[];
+};
+
 export type MatchResultDetail = MatchResultSummary & {
   criteria: MatchCriterionResult[];
+  explanation: MatchExplanation;
 };
 
 export type MatchRunResponse = {

--- a/tests/integration/test_patient_matching.py
+++ b/tests/integration/test_patient_matching.py
@@ -315,7 +315,10 @@ class TestPatientMatching:
 
         detail = client.get(f"/api/v1/matches/{ranked['NCT10000001']['id']}")
         assert detail.status_code == 200
-        outcomes = {(item["source_type"], item["category"]): item["outcome"] for item in detail.json()["criteria"]}
+        detail_payload = detail.json()
+        assert "criteria" in detail_payload
+        assert "explanation" in detail_payload
+        outcomes = {(item["source_type"], item["category"]): item["outcome"] for item in detail_payload["criteria"]}
         assert outcomes[("structured", "sex")] == "matched"
         assert outcomes[("structured", "age")] == "matched"
         assert outcomes[("extracted", "diagnosis")] == "matched"
@@ -323,9 +326,16 @@ class TestPatientMatching:
         assert outcomes[("extracted", "biomarker")] == "matched"
         assert outcomes[("extracted", "lab_value")] == "matched"
         assert ("extracted", "sex") not in outcomes
+        matched_items = {(item["category"], item["outcome"]) for item in detail_payload["explanation"]["matched"]}
+        assert ("age", "matched") in matched_items
+        assert ("diagnosis", "matched") in matched_items
+        assert detail_payload["explanation"]["blockers"] == []
+        assert detail_payload["explanation"]["review_required"] == []
+        for item in detail_payload["explanation"]["matched"]:
+            assert item["source_snippet"] is None or item["source_snippet"].strip()
         structured_sex = next(
             item
-            for item in detail.json()["criteria"]
+            for item in detail_payload["criteria"]
             if item["source_type"] == "structured" and item["category"] == "sex"
         )
         assert structured_sex["state"] == "structured_safe"
@@ -340,14 +350,28 @@ class TestPatientMatching:
         assert extracted_diagnosis["state"] == "structured_safe"
         assert extracted_diagnosis["state_reason"] is None
 
+        blocker_detail = client.get(f"/api/v1/matches/{ranked['NCT10000002']['id']}")
+        assert blocker_detail.status_code == 200
+        blocker_payload = blocker_detail.json()
+        blocker_item = next(item for item in blocker_payload["explanation"]["blockers"] if item["category"] == "sex")
+        assert blocker_item["outcome"] == "not_matched"
+        assert blocker_item["state"] == "structured_safe"
+        assert blocker_item["source_snippet"] is None or blocker_item["source_snippet"].strip()
+
         review_detail = client.get(f"/api/v1/matches/{ranked['NCT10000003']['id']}")
         assert review_detail.status_code == 200
-        review_item = next(
-            item for item in review_detail.json()["criteria"] if item["category"] == "concomitant_medication"
-        )
+        review_payload = review_detail.json()
+        review_item = next(item for item in review_payload["criteria"] if item["category"] == "concomitant_medication")
         assert review_item["outcome"] == "requires_review"
         assert review_item["state"] == "review_required"
         assert review_item["state_reason"] == "review_required:unspecified_review_reason"
+        review_explanation_item = next(
+            item
+            for item in review_payload["explanation"]["review_required"]
+            if item["category"] == "concomitant_medication"
+        )
+        assert review_explanation_item["outcome"] == "requires_review"
+        assert review_explanation_item["source_snippet"] is None or review_explanation_item["source_snippet"].strip()
 
         listing = client.get(f"/api/v1/patients/{patient_id}/matches?per_page={total_trials}")
         assert listing.status_code == 200
@@ -401,10 +425,19 @@ class TestPatientMatching:
 
         detail = client.get(f"/api/v1/matches/{result['id']}")
         assert detail.status_code == 200
-        diagnosis = next(item for item in detail.json()["criteria"] if item["category"] == "diagnosis")
+        detail_payload = detail.json()
+        diagnosis = next(item for item in detail_payload["criteria"] if item["category"] == "diagnosis")
         assert diagnosis["outcome"] == "matched"
         assert diagnosis["state"] == "structured_low_confidence"
         assert diagnosis["state_reason"] == "low_confidence"
+        matched_categories = {item["category"] for item in detail_payload["explanation"]["matched"]}
+        assert "diagnosis" in matched_categories
+        low_confidence_item = next(
+            item for item in detail_payload["explanation"]["review_required"] if item["category"] == "diagnosis"
+        )
+        assert low_confidence_item["outcome"] == "matched"
+        assert low_confidence_item["state"] == "structured_low_confidence"
+        assert low_confidence_item["source_snippet"] is None
 
     def test_reviewed_low_confidence_criterion_is_treated_as_safe_for_new_matches(self, client, db_session):
         trial = _seed_trial_with_run(


### PR DESCRIPTION
## Summary
- add grouped explanation payloads to match detail responses without removing raw criterion data
- surface explanation cards in the match detail UI for matched criteria, blockers, and uncertainty/review items
- align tests and OpenAPI/types with the new explanation contract

## What changed
### Backend
- added additive `explanation` models to `MatchResultDetail`
- grouped persisted `match_result.criteria` rows into:
  - `matched`
  - `blockers`
  - `review_required`
- kept grouping semantically aligned with persisted outcomes while also surfacing uncertainty states in the review bucket
- made `source_snippet` nullable so the API does not invent evidence text when no real snippet was captured

### Frontend
- added a reusable explanation-card component
- rendered grouped explanation cards on `/matches/[matchId]`
- preserved the raw criterion breakdown below the new summary cards
- show an explicit fallback when no direct evidence snippet was captured

### Tests / contract
- extended integration coverage for grouped explanation payload behavior
- added coverage for low-confidence criteria appearing in both semantic and uncertainty views
- regenerated checked-in OpenAPI and updated frontend API types

## Test Plan
- [x] Changed-file Ruff
- [x] Full backend pytest (`376 passed`)
- [x] Frontend typecheck
- [x] Frontend build
- [x] Local PR review gate

## Local review summary
Gate: **pass**

Checks: Changed-file Ruff=pass, Backend pytest=pass, Frontend typecheck=pass, Frontend build=pass, Local Codex review=pass

Open items:
- None.

Public gate artifact:
`/home/hermes/workspace/clinical-trial-matching/.hermes/reviews/2026-04-25_163310-feat-issue-9-evidence-grounded-match-explanations.public-summary.md`

## Closes
Closes #9
