### PR TITLE
feat: add structured match gap reporting

### DIFF
--- a/app/api/routes/patients.py
+++ b/app/api/routes/patients.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -9,6 +10,8 @@ from app.api.schemas import (
     MatchCriterionResultResponse,
     MatchExplanationItemResponse,
     MatchExplanationResponse,
+    MatchGapEntryResponse,
+    MatchGapReportResponse,
     MatchResultDetail,
     MatchResultListResponse,
     MatchResultSummary,
@@ -31,7 +34,8 @@ from app.api.schemas import (
 )
 from app.api.state import criterion_state_from_match_result_criterion, match_state_from_match_result
 from app.db.session import get_db
-from app.matching.service import PatientMatchService
+from app.matching.gap_report import build_gap_report_payload
+from app.matching.service import CriterionEvaluation, PatientMatchService, _collapse_or_group
 from app.models.database import (
     MatchResult,
     MatchRun,
@@ -498,12 +502,271 @@ def _build_match_explanation(criteria) -> MatchExplanationResponse:
     return explanation
 
 
+def _patient_flag_field_name(criterion) -> str | None:
+    evidence = criterion.evidence_payload
+    if not isinstance(evidence, dict):
+        return None
+    patient_flag_field = evidence.get("patient_flag_field")
+    if isinstance(patient_flag_field, str) and patient_flag_field:
+        return patient_flag_field
+    return None
+
+
+def _has_missing_patient_data(criterion) -> bool:
+    state_reason = getattr(criterion, "state_reason", None)
+    if state_reason == "legacy_state_unverifiable":
+        return False
+
+    evidence = criterion.evidence_payload
+    if not isinstance(evidence, dict):
+        return False
+
+    scalar_patient_keys = (
+        "patient_age_years",
+        "patient_sex",
+        "patient_is_healthy_volunteer",
+        "patient_ecog_status",
+    )
+    snapshot_missing_data = evidence.get("snapshot_missing_data")
+    if snapshot_missing_data is True:
+        return True
+    if any(key in evidence and evidence[key] is None for key in scalar_patient_keys):
+        return True
+
+    list_patient_keys = (
+        "patient_conditions",
+        "patient_biomarkers",
+        "patient_labs",
+        "patient_therapies",
+    )
+    if any(key in evidence and isinstance(evidence[key], list) and not evidence[key] for key in list_patient_keys):
+        return True
+
+    if criterion.category == "lab_value":
+        labs = evidence.get("patient_labs")
+        if (
+            isinstance(labs, list)
+            and labs
+            and all(lab.get("value_numeric") is None for lab in labs if isinstance(lab, dict))
+        ):
+            return True
+
+    if criterion.category in {"prior_therapy", "line_of_therapy"}:
+        therapies = evidence.get("patient_therapies")
+        if isinstance(therapies, list) and therapies and all(
+            therapy.get("line_of_therapy") is None for therapy in therapies if isinstance(therapy, dict)
+        ):
+            return True
+
+    patient_flags = evidence.get("patient_flags")
+    if isinstance(patient_flags, dict):
+        field_name = _patient_flag_field_name(criterion)
+        if field_name and patient_flags.get(field_name) is None:
+            return True
+
+    if criterion.category == "concomitant_medication":
+        medications = evidence.get("patient_medications")
+        if not isinstance(medications, list) or not medications:
+            return True
+        if evidence.get("exception_logic") or evidence.get("allowance_text"):
+            return False
+        if any(
+            evidence.get(key) is not None
+            for key in ("timeframe_operator", "timeframe_value", "timeframe_unit")
+        ):
+            return False
+        return False
+
+    return False
+
+
+def _is_hard_blocker(criterion, *, state: str | None = None) -> bool:
+    criterion_state = state
+    if criterion_state is None:
+        criterion_state, _ = criterion_state_from_match_result_criterion(criterion)
+    return criterion_state == "structured_safe"
+
+
+def _criterion_logic_group_key(criterion) -> tuple[object, str] | None:
+    evidence = criterion.evidence_payload
+    if not isinstance(evidence, dict):
+        return None
+    snapshot_metadata = evidence.get("snapshot_match_metadata")
+    if not isinstance(snapshot_metadata, dict):
+        return None
+    logic_group_id = snapshot_metadata.get("logic_group_id")
+    logic_operator = snapshot_metadata.get("logic_operator")
+    if logic_group_id and logic_operator == "OR":
+        return logic_group_id, logic_operator
+    return None
+
+
+def _criterion_to_evaluation(criterion) -> CriterionEvaluation:
+    logic_group_id = None
+    logic_operator = None
+    evidence = criterion.evidence_payload
+    if isinstance(evidence, dict):
+        snapshot_metadata = evidence.get("snapshot_match_metadata")
+        if isinstance(snapshot_metadata, dict):
+            logic_group_id = snapshot_metadata.get("logic_group_id")
+            logic_operator = snapshot_metadata.get("logic_operator")
+    return CriterionEvaluation(
+        criterion_id=criterion.criterion_id,
+        pipeline_run_id=criterion.pipeline_run_id,
+        logic_group_id=logic_group_id,
+        logic_operator=logic_operator,
+        source_type=criterion.source_type,
+        source_label=criterion.source_label,
+        criterion_type=criterion.criterion_type,
+        category=criterion.category,
+        criterion_text=criterion.criterion_text,
+        outcome=criterion.outcome,
+        state=criterion.state,
+        state_reason=criterion.state_reason,
+        explanation_text=criterion.explanation_text,
+        explanation_type=criterion.explanation_type,
+        evidence_payload=criterion.evidence_payload,
+    )
+
+
+def _evaluation_to_gap_criterion(evaluation: CriterionEvaluation):
+    return SimpleNamespace(
+        criterion_id=evaluation.criterion_id,
+        pipeline_run_id=evaluation.pipeline_run_id,
+        source_type=evaluation.source_type,
+        source_label=evaluation.source_label,
+        criterion_type=evaluation.criterion_type,
+        category=evaluation.category,
+        criterion_text=evaluation.criterion_text,
+        outcome=evaluation.outcome,
+        state=evaluation.state,
+        state_reason=evaluation.state_reason,
+        explanation_text=evaluation.explanation_text,
+        explanation_type=evaluation.explanation_type,
+        evidence_payload=evaluation.evidence_payload,
+        criterion=None,
+    )
+
+
+def _grouped_gap_criterion(members: list[object]):
+    collapsed = _collapse_or_group([_criterion_to_evaluation(member) for member in members])
+    member_texts = []
+    for member in members:
+        text = member.criterion_text.strip()
+        if text and text not in member_texts:
+            member_texts.append(text)
+    evidence_payload = collapsed.evidence_payload if isinstance(collapsed.evidence_payload, dict) else {}
+    return SimpleNamespace(
+        criterion_id=collapsed.criterion_id,
+        pipeline_run_id=collapsed.pipeline_run_id,
+        source_type=collapsed.source_type,
+        source_label=collapsed.source_label,
+        criterion_type=collapsed.criterion_type,
+        category=collapsed.category,
+        criterion_text=" OR ".join(member_texts) if member_texts else collapsed.criterion_text,
+        outcome=collapsed.outcome,
+        state=collapsed.state,
+        state_reason=collapsed.state_reason,
+        explanation_text=collapsed.explanation_text,
+        explanation_type=collapsed.explanation_type,
+        evidence_payload={
+            **evidence_payload,
+            "snapshot_match_metadata": {
+                "logic_group_id": str(collapsed.logic_group_id) if collapsed.logic_group_id is not None else None,
+                "logic_operator": collapsed.logic_operator,
+            },
+            "member_criterion_texts": member_texts,
+            "snapshot_missing_data": any(_has_missing_patient_data(member) for member in members),
+        },
+        criterion=None,
+    )
+
+
+def _effective_gap_report_criteria(criteria):
+    effective = []
+    grouped_members: dict[tuple[object, str], list[object]] = {}
+    grouped_order: list[tuple[object, str]] = []
+
+    for criterion in criteria:
+        key = _criterion_logic_group_key(criterion)
+        if key is not None:
+            if key not in grouped_members:
+                grouped_order.append(key)
+                grouped_members[key] = []
+            grouped_members[key].append(criterion)
+            continue
+
+        effective.append(criterion)
+
+    for key in grouped_order:
+        effective.append(_grouped_gap_criterion(grouped_members[key]))
+
+    return effective
+
+
+def _build_match_gap_entry(criterion, kind: str) -> MatchGapEntryResponse:
+    state, state_reason = criterion_state_from_match_result_criterion(criterion)
+    return MatchGapEntryResponse(
+        kind=kind,
+        label=_explanation_label_for_category(criterion.category),
+        category=criterion.category,
+        criterion_text=criterion.criterion_text,
+        outcome=criterion.outcome,
+        state=state,
+        state_reason=state_reason,
+        summary=criterion.explanation_text,
+        source_snippet=_source_snippet_for_criterion(criterion),
+        evidence_payload=criterion.evidence_payload,
+    )
+
+
+def _build_match_gap_report(criteria) -> MatchGapReportResponse:
+    return MatchGapReportResponse.model_validate(build_gap_report_payload(criteria))
+
+
+def _legacy_gap_report_payload(match_result: MatchResult) -> dict[str, list[dict[str, object | None]]]:
+    base_entry = {
+        "label": "Historical Snapshot",
+        "category": "historical_snapshot",
+        "criterion_text": "Gap report was not snapshotted for this historical match result.",
+        "state": match_result.state,
+        "state_reason": match_result.state_reason or "legacy_state_unverifiable",
+        "summary": match_result.summary_explanation,
+        "source_snippet": None,
+        "evidence_payload": None,
+    }
+    report = {
+        "hard_blockers": [],
+        "clarifiable_blockers": [],
+        "missing_data": [],
+        "review_required": [],
+        "unsupported": [],
+    }
+    if match_result.state == "blocked_unsupported":
+        report["unsupported"].append({**base_entry, "kind": "unsupported", "outcome": "unknown"})
+    if (
+        match_result.overall_status == "ineligible"
+        and match_result.unfavorable_count > 0
+        and match_result.state == "structured_safe"
+    ):
+        report["hard_blockers"].append({**base_entry, "kind": "hard_blocker", "outcome": "not_matched"})
+    if (
+        match_result.unknown_count > 0
+        or match_result.requires_review_count > 0
+        or (match_result.state not in {"structured_safe", "blocked_unsupported"})
+    ):
+        report["review_required"].append({**base_entry, "kind": "review_required", "outcome": "unknown"})
+    return report
+
+
 def _match_detail(match_result: MatchResult) -> MatchResultDetail:
     criteria = sorted(match_result.criteria, key=lambda criterion: (criterion.created_at, str(criterion.id)))
+    gap_report_payload = match_result.gap_report_payload or _legacy_gap_report_payload(match_result)
     return MatchResultDetail(
         **_match_summary(match_result).model_dump(),
         criteria=[_build_match_criterion_response(criterion) for criterion in criteria],
         explanation=_build_match_explanation(criteria),
+        gap_report=MatchGapReportResponse.model_validate(gap_report_payload),
     )
 
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -509,6 +509,33 @@ class MatchExplanationResponse(APIModel):
     review_required: list[MatchExplanationItemResponse] = Field(default_factory=list)
 
 
+class MatchGapEntryResponse(APIModel):
+    kind: Literal[
+        "hard_blocker",
+        "clarifiable_blocker",
+        "missing_data",
+        "review_required",
+        "unsupported",
+    ]
+    label: str
+    category: str
+    criterion_text: str
+    outcome: CriterionMatchOutcome
+    state: ConfidenceState
+    state_reason: str | None = None
+    summary: str | None = None
+    source_snippet: str | None = None
+    evidence_payload: dict[str, Any] | None = None
+
+
+class MatchGapReportResponse(APIModel):
+    hard_blockers: list[MatchGapEntryResponse] = Field(default_factory=list)
+    clarifiable_blockers: list[MatchGapEntryResponse] = Field(default_factory=list)
+    missing_data: list[MatchGapEntryResponse] = Field(default_factory=list)
+    review_required: list[MatchGapEntryResponse] = Field(default_factory=list)
+    unsupported: list[MatchGapEntryResponse] = Field(default_factory=list)
+
+
 class MatchResultSummary(APIModel):
     id: UUID
     match_run_id: UUID
@@ -536,6 +563,7 @@ class MatchResultSummary(APIModel):
 class MatchResultDetail(MatchResultSummary):
     criteria: list[MatchCriterionResultResponse] = Field(default_factory=list)
     explanation: MatchExplanationResponse = Field(default_factory=MatchExplanationResponse)
+    gap_report: MatchGapReportResponse = Field(default_factory=MatchGapReportResponse)
 
 
 class MatchRunResponse(APIModel):

--- a/app/db/migrations/versions/0008_add_gap_report_payload_to_match_results.py
+++ b/app/db/migrations/versions/0008_add_gap_report_payload_to_match_results.py
@@ -1,0 +1,99 @@
+"""add gap report payload to match results
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-25 00:00:00.000000
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0008"
+down_revision: Union[str, None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _backfilled_gap_report(row) -> dict[str, list[dict[str, object | None]]]:
+    base_entry = {
+        "label": "Historical Snapshot",
+        "category": "historical_snapshot",
+        "criterion_text": "Gap report was not snapshotted for this historical match result.",
+        "state": row["state"],
+        "state_reason": row["state_reason"] or "legacy_state_unverifiable",
+        "summary": row["summary_explanation"],
+        "source_snippet": None,
+        "evidence_payload": None,
+    }
+    report = {
+        "hard_blockers": [],
+        "clarifiable_blockers": [],
+        "missing_data": [],
+        "review_required": [],
+        "unsupported": [],
+    }
+    if row["state"] == "blocked_unsupported":
+        report["unsupported"].append({**base_entry, "kind": "unsupported", "outcome": "unknown"})
+    if (
+        row["overall_status"] == "ineligible"
+        and (row["unfavorable_count"] or 0) > 0
+        and row["state"] == "structured_safe"
+    ):
+        report["hard_blockers"].append({**base_entry, "kind": "hard_blocker", "outcome": "not_matched"})
+    if (
+        (row["unknown_count"] or 0) > 0
+        or (row["requires_review_count"] or 0) > 0
+        or (row["state"] not in {"structured_safe", "blocked_unsupported"})
+    ):
+        report["review_required"].append({**base_entry, "kind": "review_required", "outcome": "unknown"})
+    return report
+
+
+def upgrade() -> None:
+    op.add_column(
+        "match_results",
+        sa.Column("gap_report_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text(
+            """
+            SELECT
+                id,
+                overall_status,
+                unfavorable_count,
+                unknown_count,
+                requires_review_count,
+                state,
+                state_reason,
+                summary_explanation
+            FROM match_results
+            """
+        )
+    ).mappings()
+
+    updates = []
+    for row in rows:
+        updates.append({"id": row["id"], "gap_report_payload": json.dumps(_backfilled_gap_report(row))})
+
+    if updates:
+        connection.execute(
+            sa.text(
+                """
+                UPDATE match_results
+                SET gap_report_payload = CAST(:gap_report_payload AS JSONB)
+                WHERE id = :id
+                """
+            ),
+            updates,
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("match_results", "gap_report_payload")

--- a/app/matching/gap_report.py
+++ b/app/matching/gap_report.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+
+def _label_for_category(category: str) -> str:
+    return category.replace("_", " ").title()
+
+
+def _source_snippet_for_payload(evidence_payload: dict[str, Any] | None) -> str | None:
+    if not isinstance(evidence_payload, dict):
+        return None
+    explicit_snippet = evidence_payload.get("source_snippet") or evidence_payload.get("source_text")
+    if isinstance(explicit_snippet, str) and explicit_snippet.strip():
+        return explicit_snippet.strip()
+    return None
+
+
+def _patient_flag_field_name(item) -> str | None:
+    evidence = getattr(item, "evidence_payload", None)
+    if not isinstance(evidence, dict):
+        return None
+    patient_flag_field = evidence.get("patient_flag_field")
+    if isinstance(patient_flag_field, str) and patient_flag_field:
+        return patient_flag_field
+    return None
+
+
+def _has_missing_patient_data(item) -> bool:
+    state_reason = getattr(item, "state_reason", None)
+    if state_reason == "legacy_state_unverifiable":
+        return False
+
+    evidence = getattr(item, "evidence_payload", None)
+    if not isinstance(evidence, dict):
+        return False
+
+    if evidence.get("snapshot_missing_data") is True:
+        return True
+
+    scalar_patient_keys = (
+        "patient_age_years",
+        "patient_sex",
+        "patient_is_healthy_volunteer",
+        "patient_ecog_status",
+    )
+    if any(key in evidence and evidence[key] is None for key in scalar_patient_keys):
+        return True
+
+    list_patient_keys = (
+        "patient_conditions",
+        "patient_biomarkers",
+        "patient_labs",
+        "patient_therapies",
+    )
+    if any(key in evidence and isinstance(evidence[key], list) and not evidence[key] for key in list_patient_keys):
+        return True
+
+    if getattr(item, "category", None) == "lab_value":
+        labs = evidence.get("patient_labs")
+        if (
+            isinstance(labs, list)
+            and labs
+            and all(lab.get("value_numeric") is None for lab in labs if isinstance(lab, dict))
+        ):
+            return True
+
+    if getattr(item, "category", None) in {"prior_therapy", "line_of_therapy"}:
+        therapies = evidence.get("patient_therapies")
+        if isinstance(therapies, list) and therapies and all(
+            therapy.get("line_of_therapy") is None for therapy in therapies if isinstance(therapy, dict)
+        ):
+            return True
+
+    patient_flags = evidence.get("patient_flags")
+    if isinstance(patient_flags, dict):
+        field_name = _patient_flag_field_name(item)
+        if field_name and patient_flags.get(field_name) is None:
+            return True
+
+    if getattr(item, "category", None) == "concomitant_medication":
+        medications = evidence.get("patient_medications")
+        if not isinstance(medications, list) or not medications:
+            return True
+        if evidence.get("exception_logic") or evidence.get("allowance_text"):
+            return False
+        if any(
+            evidence.get(key) is not None
+            for key in ("timeframe_operator", "timeframe_value", "timeframe_unit")
+        ):
+            return False
+        return False
+
+    return False
+
+
+def _is_hard_blocker(item) -> bool:
+    return getattr(item, "state", None) == "structured_safe"
+
+
+def _group_key(item) -> tuple[object, str] | None:
+    evidence = getattr(item, "evidence_payload", None)
+    if not isinstance(evidence, dict):
+        return None
+    snapshot_metadata = evidence.get("snapshot_match_metadata")
+    if isinstance(snapshot_metadata, dict):
+        logic_group_id = snapshot_metadata.get("logic_group_id")
+        logic_operator = snapshot_metadata.get("logic_operator")
+        if logic_group_id and logic_operator == "OR":
+            return logic_group_id, logic_operator
+    logic_group_id = evidence.get("logic_group_id")
+    logic_operator = evidence.get("logic_operator")
+    if logic_group_id and logic_operator == "OR":
+        return logic_group_id, logic_operator
+    return None
+
+
+def _collapsed_group_state(items: list[Any]) -> tuple[str, str | None, str | None]:
+    exemplar = items[0]
+    outcomes = {getattr(item, "outcome", None) for item in items}
+    criterion_type = getattr(exemplar, "criterion_type", None)
+
+    if criterion_type == "inclusion":
+        if "matched" in outcomes:
+            outcome = "matched"
+        elif "requires_review" in outcomes:
+            outcome = "requires_review"
+        elif "unknown" in outcomes:
+            outcome = "unknown"
+        else:
+            outcome = "not_matched"
+    else:
+        if "triggered" in outcomes:
+            outcome = "triggered"
+        elif "requires_review" in outcomes:
+            outcome = "requires_review"
+        elif "unknown" in outcomes:
+            outcome = "unknown"
+        else:
+            outcome = "not_triggered"
+
+    matching_members = [item for item in items if getattr(item, "outcome", None) == outcome] or items
+    state_members = items if outcome in {"not_matched", "not_triggered", "unknown"} else matching_members
+    member_states = {getattr(item, "state", None) for item in state_members}
+
+    if outcome in {"not_matched", "not_triggered", "unknown"}:
+        if "review_required" in member_states:
+            return outcome, "review_required", "review_required"
+        if "blocked_unsupported" in member_states:
+            return outcome, "blocked_unsupported", "blocked_unsupported"
+        if "structured_low_confidence" in member_states:
+            return outcome, "structured_low_confidence", "low_confidence"
+        if "structured_safe" in member_states:
+            return outcome, "structured_safe", None
+    else:
+        if "structured_safe" in member_states:
+            return outcome, "structured_safe", None
+        if "structured_low_confidence" in member_states:
+            return outcome, "structured_low_confidence", "low_confidence"
+        if "review_required" in member_states:
+            return outcome, "review_required", "review_required"
+        if "blocked_unsupported" in member_states:
+            return outcome, "blocked_unsupported", "blocked_unsupported"
+
+    return outcome, getattr(exemplar, "state", None), getattr(exemplar, "state_reason", None)
+
+
+def _group_display_item(items: list[Any]):
+    exemplar = items[0]
+    collapsed_outcome, collapsed_state, collapsed_state_reason = _collapsed_group_state(items)
+    evidence = getattr(exemplar, "evidence_payload", None)
+    evidence_payload = evidence if isinstance(evidence, dict) else {}
+    member_texts = evidence_payload.get("member_criterion_texts")
+    if not isinstance(member_texts, list) or not member_texts:
+        member_texts = [getattr(item, "criterion_text", "") for item in items if getattr(item, "criterion_text", "")]
+    member_categories = evidence_payload.get("member_categories")
+    if not isinstance(member_categories, list) or not member_categories:
+        member_categories = [getattr(item, "category", None) for item in items if getattr(item, "category", None)]
+    category = member_categories[0] if member_categories and len(set(member_categories)) == 1 else "logic_group"
+    criterion_text = (
+        " OR ".join(dict.fromkeys(member_texts))
+        if member_texts
+        else getattr(exemplar, "criterion_text", "")
+    )
+    merged_evidence = {
+        **evidence_payload,
+        "member_criterion_texts": list(dict.fromkeys(member_texts)),
+        "member_categories": list(dict.fromkeys(member_categories)),
+        "snapshot_missing_data": any(_has_missing_patient_data(item) for item in items),
+    }
+    return SimpleNamespace(
+        criterion_id=getattr(exemplar, "criterion_id", None),
+        pipeline_run_id=getattr(exemplar, "pipeline_run_id", None),
+        source_type=getattr(exemplar, "source_type", None),
+        source_label=getattr(exemplar, "source_label", None),
+        criterion_type=getattr(exemplar, "criterion_type", None),
+        category=category,
+        criterion_text=criterion_text,
+        outcome=collapsed_outcome,
+        state=collapsed_state,
+        state_reason=collapsed_state_reason,
+        explanation_text=getattr(exemplar, "explanation_text", None),
+        explanation_type=getattr(exemplar, "explanation_type", None),
+        evidence_payload=merged_evidence,
+    )
+
+
+def _effective_items(items: list[Any]) -> list[Any]:
+    grouped: dict[tuple[object, str], list[Any]] = {}
+    grouped_order: list[tuple[object, str]] = []
+    effective: list[Any] = []
+    for item in items:
+        key = _group_key(item)
+        if key is None:
+            effective.append(item)
+            continue
+        if key not in grouped:
+            grouped_order.append(key)
+            grouped[key] = []
+        grouped[key].append(item)
+    for key in grouped_order:
+        effective.append(_group_display_item(grouped[key]))
+    return effective
+
+
+def _build_entry(item, kind: str) -> dict[str, Any]:
+    evidence_payload = getattr(item, "evidence_payload", None)
+    return {
+        "kind": kind,
+        "label": _label_for_category(getattr(item, "category", "logic_group")),
+        "category": getattr(item, "category", "logic_group"),
+        "criterion_text": getattr(item, "criterion_text", ""),
+        "outcome": getattr(item, "outcome", None),
+        "state": getattr(item, "state", None),
+        "state_reason": getattr(item, "state_reason", None),
+        "summary": getattr(item, "explanation_text", None),
+        "source_snippet": _source_snippet_for_payload(evidence_payload),
+        "evidence_payload": evidence_payload,
+    }
+
+
+def build_gap_report_payload(items: list[Any]) -> dict[str, list[dict[str, Any]]]:
+    report = {
+        "hard_blockers": [],
+        "clarifiable_blockers": [],
+        "missing_data": [],
+        "review_required": [],
+        "unsupported": [],
+    }
+    for item in _effective_items(items):
+        state = getattr(item, "state", None)
+        outcome = getattr(item, "outcome", None)
+        state_reason = getattr(item, "state_reason", None)
+
+        if state == "blocked_unsupported":
+            report["unsupported"].append(_build_entry(item, "unsupported"))
+            continue
+
+        if outcome == "unknown" and state_reason == "legacy_state_unverifiable":
+            report["review_required"].append(_build_entry(item, "review_required"))
+            continue
+
+        if outcome == "requires_review" or (state == "review_required" and outcome != "unknown"):
+            report["review_required"].append(_build_entry(item, "review_required"))
+            continue
+
+        if outcome == "unknown" and state == "review_required":
+            report["review_required"].append(_build_entry(item, "review_required"))
+            continue
+
+        if outcome == "unknown" and _has_missing_patient_data(item):
+            report["missing_data"].append(_build_entry(item, "missing_data"))
+            continue
+
+        if outcome in {"not_matched", "triggered"}:
+            if state == "structured_low_confidence" and not _is_hard_blocker(item):
+                report["clarifiable_blockers"].append(_build_entry(item, "clarifiable_blocker"))
+            elif _is_hard_blocker(item):
+                report["hard_blockers"].append(_build_entry(item, "hard_blocker"))
+            else:
+                report["clarifiable_blockers"].append(_build_entry(item, "clarifiable_blocker"))
+            continue
+
+        if outcome == "unknown":
+            report["review_required"].append(_build_entry(item, "review_required"))
+            continue
+
+        if state == "structured_low_confidence" and outcome in {"matched", "not_triggered"}:
+            report["review_required"].append(_build_entry(item, "review_required"))
+    return report

--- a/app/matching/service.py
+++ b/app/matching/service.py
@@ -6,6 +6,7 @@ from typing import Any, Iterable
 from sqlalchemy.orm import Session, selectinload
 
 from app.api.state import criterion_state_from_extracted, match_state_from_evaluations
+from app.matching.gap_report import build_gap_report_payload
 from app.models.database import (
     ExtractedCriterion,
     MatchResult,
@@ -130,12 +131,24 @@ class PatientMatchService:
                 unknown_count=unknown_count,
                 requires_review_count=requires_review_count,
                 summary_explanation=summary_explanation,
+                gap_report_payload=build_gap_report_payload(effective_evaluations),
                 created_at=utc_now(),
             )
             self._db.add(result)
             self._db.flush()
 
             for evaluation in evaluations:
+                evidence_payload = evaluation.evidence_payload
+                if isinstance(evidence_payload, dict):
+                    evidence_payload = {
+                        **evidence_payload,
+                        "snapshot_match_metadata": {
+                            "logic_group_id": (
+                                str(evaluation.logic_group_id) if evaluation.logic_group_id is not None else None
+                            ),
+                            "logic_operator": evaluation.logic_operator,
+                        },
+                    }
                 self._db.add(
                     MatchResultCriterion(
                         match_result_id=result.id,
@@ -151,7 +164,7 @@ class PatientMatchService:
                         state_reason=evaluation.state_reason,
                         explanation_text=evaluation.explanation_text,
                         explanation_type=evaluation.explanation_type,
-                        evidence_payload=evaluation.evidence_payload,
+                        evidence_payload=evidence_payload,
                     )
                 )
 
@@ -468,6 +481,59 @@ def _latest_completed_run(trial: Trial) -> PipelineRun | None:
     )[0]
 
 
+def _evaluation_has_explicit_missing_patient_data(evaluation: CriterionEvaluation) -> bool:
+    evidence = evaluation.evidence_payload
+    if not isinstance(evidence, dict):
+        return False
+
+    scalar_patient_keys = (
+        "patient_age_years",
+        "patient_sex",
+        "patient_is_healthy_volunteer",
+        "patient_ecog_status",
+    )
+    if any(key in evidence and evidence[key] is None for key in scalar_patient_keys):
+        return True
+
+    list_patient_keys = (
+        "patient_conditions",
+        "patient_biomarkers",
+        "patient_labs",
+        "patient_therapies",
+    )
+    if any(key in evidence and isinstance(evidence[key], list) and not evidence[key] for key in list_patient_keys):
+        return True
+
+    if evaluation.category == "lab_value":
+        labs = evidence.get("patient_labs")
+        if (
+            isinstance(labs, list)
+            and labs
+            and all(lab.get("value_numeric") is None for lab in labs if isinstance(lab, dict))
+        ):
+            return True
+
+    if evaluation.category in {"prior_therapy", "line_of_therapy"}:
+        therapies = evidence.get("patient_therapies")
+        if isinstance(therapies, list) and therapies and all(
+            therapy.get("line_of_therapy") is None for therapy in therapies if isinstance(therapy, dict)
+        ):
+            return True
+
+    patient_flags = evidence.get("patient_flags")
+    patient_flag_field = evidence.get("patient_flag_field")
+    if isinstance(patient_flags, dict) and isinstance(patient_flag_field, str):
+        if patient_flags.get(patient_flag_field) is None:
+            return True
+
+    if evaluation.category == "concomitant_medication":
+        medications = evidence.get("patient_medications")
+        if not isinstance(medications, list) or not medications:
+            return True
+
+    return False
+
+
 def _collapse_logic_group_evaluations(evaluations: list[CriterionEvaluation]) -> list[CriterionEvaluation]:
     collapsed: list[CriterionEvaluation] = []
     grouped: dict[tuple[object, str], list[CriterionEvaluation]] = {}
@@ -530,6 +596,7 @@ def _collapse_or_group(evaluations: list[CriterionEvaluation]) -> CriterionEvalu
         else matching_members
     )
     member_states = {evaluation.state for evaluation in state_members}
+    member_texts = [evaluation.criterion_text for evaluation in evaluations]
     if outcome in {"not_matched", "not_triggered", "unknown"}:
         if "review_required" in member_states:
             state = "review_required"
@@ -563,6 +630,7 @@ def _collapse_or_group(evaluations: list[CriterionEvaluation]) -> CriterionEvalu
             state = exemplar.state
             state_reason = exemplar.state_reason
 
+    member_texts = [evaluation.criterion_text for evaluation in evaluations]
     return CriterionEvaluation(
         criterion_id=None,
         pipeline_run_id=exemplar.pipeline_run_id,
@@ -572,7 +640,7 @@ def _collapse_or_group(evaluations: list[CriterionEvaluation]) -> CriterionEvalu
         source_label=exemplar.source_label,
         criterion_type=exemplar.criterion_type,
         category=exemplar.category,
-        criterion_text=exemplar.criterion_text,
+        criterion_text=" OR ".join(dict.fromkeys(member_texts)),
         outcome=outcome,
         state=state,
         state_reason=state_reason,
@@ -583,6 +651,11 @@ def _collapse_or_group(evaluations: list[CriterionEvaluation]) -> CriterionEvalu
             "logic_operator": exemplar.logic_operator,
             "member_outcomes": [evaluation.outcome for evaluation in evaluations],
             "member_states": [evaluation.state for evaluation in evaluations],
+            "member_criterion_texts": member_texts,
+            "member_categories": [evaluation.category for evaluation in evaluations],
+            "snapshot_missing_data": any(
+                _evaluation_has_explicit_missing_patient_data(evaluation) for evaluation in evaluations
+            ),
         },
     )
 
@@ -899,6 +972,8 @@ def _build_extracted_explanation(
             "pregnant": patient.pregnant,
             "mr_device_present": patient.mr_device_present,
         }
+        parsed_flag = _parse_patient_flag_expression(criterion.value_text)
+        evidence["patient_flag_field"] = parsed_flag[0] if parsed_flag is not None else None
     elif criterion.category in {"performance_status"}:
         evidence["patient_ecog_status"] = patient.ecog_status
     else:

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -332,6 +332,7 @@ class MatchResult(Base):
     unknown_count = Column(Integer, nullable=False, default=0)
     requires_review_count = Column(Integer, nullable=False, default=0)
     summary_explanation = Column(Text)
+    gap_report_payload = Column(JSONB)
     state = Column(String, nullable=False)
     state_reason = Column(String)
     created_at = Column(DateTime(timezone=True), nullable=False, default=utc_now)

--- a/frontend/src/app/matches/[matchId]/page.tsx
+++ b/frontend/src/app/matches/[matchId]/page.tsx
@@ -2,6 +2,7 @@ import { StructuredDataView } from "@/components/structured-data-view";
 import Link from "next/link";
 
 import { MatchExplanationCard } from "@/components/match-explanation-card";
+import { MatchGapReportCard } from "@/components/match-gap-report-card";
 import { PageHeader } from "@/components/page-header";
 import { Panel } from "@/components/panel";
 import { StatusPill } from "@/components/status-pill";
@@ -83,6 +84,44 @@ export default async function MatchDetailPage({
             eyebrow="Unresolved criteria"
             items={match.explanation.review_required}
             emptyMessage="No unresolved or review-required criteria remain for this result."
+          />
+        </div>
+      </Panel>
+
+      <Panel title="Match-Gap Report" eyebrow="Why this result is not yet fully actionable">
+        <p className="text-sm leading-7 text-ink/72">
+          The gap report separates hard blockers from clarifiable blockers, missing patient data, review-required criteria, and unsupported logic.
+        </p>
+        <div className="mt-6 grid gap-4 xl:grid-cols-2">
+          <MatchGapReportCard
+            title="Hard blockers"
+            eyebrow="Likely incompatible"
+            items={match.gap_report.hard_blockers}
+            emptyMessage="No hard blockers were detected for this result."
+          />
+          <MatchGapReportCard
+            title="Clarifiable blockers"
+            eyebrow="Could change with better evidence"
+            items={match.gap_report.clarifiable_blockers}
+            emptyMessage="No clarifiable blockers were detected for this result."
+          />
+          <MatchGapReportCard
+            title="Missing data"
+            eyebrow="Need more patient information"
+            items={match.gap_report.missing_data}
+            emptyMessage="No missing-data gaps were detected for this result."
+          />
+          <MatchGapReportCard
+            title="Review required"
+            eyebrow="Needs human confirmation"
+            items={match.gap_report.review_required}
+            emptyMessage="No review-required gaps remain for this result."
+          />
+          <MatchGapReportCard
+            title="Unsupported"
+            eyebrow="Not safely automated"
+            items={match.gap_report.unsupported}
+            emptyMessage="No unsupported gaps were detected for this result."
           />
         </div>
       </Panel>

--- a/frontend/src/components/match-gap-report-card.tsx
+++ b/frontend/src/components/match-gap-report-card.tsx
@@ -1,0 +1,50 @@
+import { StatusPill } from "@/components/status-pill";
+import type { MatchGapEntry } from "@/lib/api/types";
+
+export function MatchGapReportCard({
+  title,
+  eyebrow,
+  emptyMessage,
+  items
+}: {
+  title: string;
+  eyebrow: string;
+  emptyMessage: string;
+  items: MatchGapEntry[];
+}) {
+  return (
+    <article className="rounded-[30px] border border-ink/10 bg-white/75 p-6 shadow-card">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-tide">{eyebrow}</p>
+          <h3 className="mt-2 text-lg font-semibold text-ink">{title}</h3>
+        </div>
+        <p className="text-sm font-semibold text-ink/55">{items.length}</p>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-sm leading-7 text-ink/65">{emptyMessage}</p>
+      ) : (
+        <div className="grid gap-4">
+          {items.map((item, index) => (
+            <div key={`${item.kind}-${item.category}-${index}`} className="rounded-3xl border border-ink/8 bg-sand/55 p-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill value={item.state} />
+                <span className="text-xs uppercase tracking-[0.22em] text-ink/45">{item.label}</span>
+                <span className="text-xs uppercase tracking-[0.22em] text-ink/35">{item.kind.replaceAll("_", " ")}</span>
+              </div>
+              <p className="mt-3 text-sm font-semibold text-ink">{item.criterion_text}</p>
+              <p className="mt-2 text-sm leading-7 text-ink/72">{item.summary ?? "No additional summary was captured for this gap."}</p>
+              <div className="mt-3 rounded-2xl bg-white/70 px-4 py-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-ink/45">Evidence reference</p>
+                <p className="mt-2 text-sm leading-7 text-ink/72">
+                  {item.source_snippet ?? "No direct evidence snippet captured for this gap yet."}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/lib/api/openapi.json
+++ b/frontend/src/lib/api/openapi.json
@@ -1448,6 +1448,153 @@
         "title": "MatchExplanationResponse",
         "type": "object"
       },
+      "MatchGapEntryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "criterion_text": {
+            "title": "Criterion Text",
+            "type": "string"
+          },
+          "evidence_payload": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence Payload"
+          },
+          "kind": {
+            "enum": [
+              "hard_blocker",
+              "clarifiable_blocker",
+              "missing_data",
+              "review_required",
+              "unsupported"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "outcome": {
+            "enum": [
+              "matched",
+              "not_matched",
+              "unknown",
+              "requires_review",
+              "not_triggered",
+              "triggered"
+            ],
+            "title": "Outcome",
+            "type": "string"
+          },
+          "source_snippet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Snippet"
+          },
+          "state": {
+            "enum": [
+              "structured_safe",
+              "structured_low_confidence",
+              "review_required",
+              "blocked_unsupported"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "state_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Reason"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          }
+        },
+        "required": [
+          "kind",
+          "label",
+          "category",
+          "criterion_text",
+          "outcome",
+          "state"
+        ],
+        "title": "MatchGapEntryResponse",
+        "type": "object"
+      },
+      "MatchGapReportResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "clarifiable_blockers": {
+            "items": {
+              "$ref": "#/components/schemas/MatchGapEntryResponse"
+            },
+            "title": "Clarifiable Blockers",
+            "type": "array"
+          },
+          "hard_blockers": {
+            "items": {
+              "$ref": "#/components/schemas/MatchGapEntryResponse"
+            },
+            "title": "Hard Blockers",
+            "type": "array"
+          },
+          "missing_data": {
+            "items": {
+              "$ref": "#/components/schemas/MatchGapEntryResponse"
+            },
+            "title": "Missing Data",
+            "type": "array"
+          },
+          "review_required": {
+            "items": {
+              "$ref": "#/components/schemas/MatchGapEntryResponse"
+            },
+            "title": "Review Required",
+            "type": "array"
+          },
+          "unsupported": {
+            "items": {
+              "$ref": "#/components/schemas/MatchGapEntryResponse"
+            },
+            "title": "Unsupported",
+            "type": "array"
+          }
+        },
+        "title": "MatchGapReportResponse",
+        "type": "object"
+      },
       "MatchResultDetail": {
         "additionalProperties": false,
         "properties": {
@@ -1492,6 +1639,9 @@
           "favorable_count": {
             "title": "Favorable Count",
             "type": "integer"
+          },
+          "gap_report": {
+            "$ref": "#/components/schemas/MatchGapReportResponse"
           },
           "id": {
             "format": "uuid",

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -303,9 +303,38 @@ export type MatchExplanation = {
   review_required: MatchExplanationItem[];
 };
 
+export type MatchGapKind =
+  | "hard_blocker"
+  | "clarifiable_blocker"
+  | "missing_data"
+  | "review_required"
+  | "unsupported";
+
+export type MatchGapEntry = {
+  kind: MatchGapKind;
+  label: string;
+  category: string;
+  criterion_text: string;
+  outcome: "matched" | "not_matched" | "unknown" | "requires_review" | "not_triggered" | "triggered";
+  state: MatchConfidenceState;
+  state_reason?: string | null;
+  summary?: string | null;
+  source_snippet?: string | null;
+  evidence_payload?: Record<string, unknown> | null;
+};
+
+export type MatchGapReport = {
+  hard_blockers: MatchGapEntry[];
+  clarifiable_blockers: MatchGapEntry[];
+  missing_data: MatchGapEntry[];
+  review_required: MatchGapEntry[];
+  unsupported: MatchGapEntry[];
+};
+
 export type MatchResultDetail = MatchResultSummary & {
   criteria: MatchCriterionResult[];
   explanation: MatchExplanation;
+  gap_report: MatchGapReport;
 };
 
 export type MatchRunResponse = {

--- a/tests/integration/test_patient_matching.py
+++ b/tests/integration/test_patient_matching.py
@@ -382,6 +382,158 @@ class TestPatientMatching:
             "NCT10000003",
         }.issubset({item["trial_nct_id"] for item in listing.json()["items"]})
 
+    def test_match_detail_surfaces_structured_gap_report_buckets(self, client, db_session):
+        _seed_trial_with_run(
+            db_session,
+            nct_id="NCT10000020",
+            sex="ALL",
+            criteria_payloads=[
+                {
+                    "type": "inclusion",
+                    "category": "diagnosis",
+                    "original_text": "Metastatic breast cancer",
+                    "coded_concepts": [
+                        {"system": "mesh", "code": "D001943", "display": "Breast Neoplasms"}
+                    ],
+                    "confidence": 0.4,
+                }
+            ],
+        )
+        _seed_trial_with_run(
+            db_session,
+            nct_id="NCT10000021",
+            sex="ALL",
+            criteria_payloads=[
+                {
+                    "type": "exclusion",
+                    "category": "concomitant_medication",
+                    "original_text": "Concurrent warfarin use requires review",
+                    "review_required": True,
+                    "review_reason": "unspecified_review_reason",
+                }
+            ],
+        )
+        unsupported_trial = _seed_trial_with_run(
+            db_session,
+            nct_id="NCT10000022",
+            sex="ALL",
+            criteria_payloads=[
+                {
+                    "type": "inclusion",
+                    "category": "diagnosis",
+                    "original_text": "Metastatic breast cancer",
+                    "coded_concepts": [
+                        {"system": "mesh", "code": "D001943", "display": "Breast Neoplasms"}
+                    ],
+                    "review_required": True,
+                    "review_reason": "fuzzy_match",
+                }
+            ],
+        )
+        unsupported_criterion_id = str(unsupported_trial.criteria[0].id)
+        reject_response = client.patch(
+            f"/api/v1/criteria/{unsupported_criterion_id}/review",
+            json={"action": "reject", "reviewed_by": "ops-console"},
+        )
+        assert reject_response.status_code == 200
+        _seed_trial_with_run(
+            db_session,
+            nct_id="NCT10000023",
+            sex="MALE",
+            criteria_payloads=[],
+        )
+        _seed_trial_with_run(
+            db_session,
+            nct_id="NCT10000024",
+            sex="ALL",
+            criteria_payloads=[
+                {
+                    "type": "inclusion",
+                    "category": "sex",
+                    "original_text": "Male patients only",
+                    "value_text": "male",
+                    "confidence": 0.4,
+                }
+            ],
+        )
+
+        patient = client.post(
+            "/api/v1/patients",
+            json={
+                "external_id": "pt-gap-report-001",
+                "sex": "female",
+                "conditions": [
+                    {
+                        "description": "Glioblastoma",
+                        "coded_concepts": [{"system": "mesh", "code": "D005909", "display": "Glioblastoma"}],
+                    }
+                ],
+            },
+        )
+        patient_id = patient.json()["id"]
+
+        response = client.post(f"/api/v1/patients/{patient_id}/match")
+        assert response.status_code == 200
+        results = {item["trial_nct_id"]: item for item in response.json()["results"]}
+
+        clarifiable_detail = client.get(f"/api/v1/matches/{results['NCT10000020']['id']}")
+        assert clarifiable_detail.status_code == 200
+        clarifiable_payload = clarifiable_detail.json()
+        assert "gap_report" in clarifiable_payload
+        clarifiable_items = [
+            item
+            for item in clarifiable_payload["gap_report"]["clarifiable_blockers"]
+            if item["category"] == "diagnosis"
+        ]
+        assert len(clarifiable_items) == 1
+        clarifiable_item = clarifiable_items[0]
+        assert clarifiable_item["kind"] == "clarifiable_blocker"
+
+        review_detail = client.get(f"/api/v1/matches/{results['NCT10000021']['id']}")
+        assert review_detail.status_code == 200
+        review_payload = review_detail.json()
+        review_item = next(
+            item
+            for item in review_payload["gap_report"]["review_required"]
+            if item["category"] == "concomitant_medication"
+        )
+        assert review_item["kind"] == "review_required"
+
+        unsupported_detail = client.get(f"/api/v1/matches/{results['NCT10000022']['id']}")
+        assert unsupported_detail.status_code == 200
+        unsupported_payload = unsupported_detail.json()
+        unsupported_item = next(
+            item for item in unsupported_payload["gap_report"]["unsupported"] if item["category"] == "diagnosis"
+        )
+        assert unsupported_item["kind"] == "unsupported"
+
+        hard_blocker_detail = client.get(f"/api/v1/matches/{results['NCT10000023']['id']}")
+        assert hard_blocker_detail.status_code == 200
+        hard_blocker_payload = hard_blocker_detail.json()
+        hard_blocker_item = next(
+            item
+            for item in hard_blocker_payload["gap_report"]["hard_blockers"]
+            if item["category"] == "sex"
+        )
+        assert hard_blocker_item["kind"] == "hard_blocker"
+        missing_data_item = next(
+            item
+            for item in hard_blocker_payload["gap_report"]["missing_data"]
+            if item["category"] == "age"
+        )
+        assert missing_data_item["kind"] == "missing_data"
+
+        low_confidence_sex_detail = client.get(f"/api/v1/matches/{results['NCT10000024']['id']}")
+        assert low_confidence_sex_detail.status_code == 200
+        low_confidence_sex_payload = low_confidence_sex_detail.json()
+        low_confidence_sex_items = [
+            item
+            for item in low_confidence_sex_payload["gap_report"]["clarifiable_blockers"]
+            if item["category"] == "sex"
+        ]
+        assert len(low_confidence_sex_items) == 1
+        assert low_confidence_sex_payload["gap_report"]["hard_blockers"] == []
+
     def test_match_patient_surfaces_low_confidence_state_separately_from_review_required(self, client, db_session):
         _seed_trial_with_run(
             db_session,
@@ -438,6 +590,11 @@ class TestPatientMatching:
         assert low_confidence_item["outcome"] == "matched"
         assert low_confidence_item["state"] == "structured_low_confidence"
         assert low_confidence_item["source_snippet"] is None
+        low_confidence_gap_item = next(
+            item for item in detail_payload["gap_report"]["review_required"] if item["category"] == "diagnosis"
+        )
+        assert low_confidence_gap_item["kind"] == "review_required"
+        assert detail_payload["gap_report"]["clarifiable_blockers"] == []
 
     def test_reviewed_low_confidence_criterion_is_treated_as_safe_for_new_matches(self, client, db_session):
         trial = _seed_trial_with_run(
@@ -596,6 +753,17 @@ class TestPatientMatching:
         assert result["overall_status"] == "eligible"
         assert result["state"] == "structured_safe"
         assert result["state_reason"] is None
+
+        detail = client.get(f"/api/v1/matches/{result['id']}")
+        assert detail.status_code == 200
+        gap_report = detail.json()["gap_report"]
+        assert gap_report == {
+            "hard_blockers": [],
+            "clarifiable_blockers": [],
+            "missing_data": [],
+            "review_required": [],
+            "unsupported": [],
+        }
 
     def test_match_state_is_snapshotted_and_does_not_drift_after_review_resolution(self, client, db_session):
         trial = _seed_trial_with_run(
@@ -818,15 +986,22 @@ class TestPatientMatching:
 
         detail = client.get(f"/api/v1/matches/{result['id']}")
         assert detail.status_code == 200
+        payload = detail.json()
         outcomes = {
             item["criterion_text"]: item["outcome"]
-            for item in detail.json()["criteria"]
+            for item in payload["criteria"]
             if item["source_type"] == "extracted"
         }
         assert outcomes["Able to provide informed consent"] == "matched"
         assert outcomes["Claustrophobia preventing MRI"] == "not_triggered"
         assert outcomes["Pregnant women are excluded"] == "not_triggered"
         assert outcomes["Presence of an MR-incompatible pacemaker"] == "unknown"
+        pacemaker_gap = next(
+            item
+            for item in payload["gap_report"]["missing_data"]
+            if item["criterion_text"] == "Presence of an MR-incompatible pacemaker"
+        )
+        assert pacemaker_gap["kind"] == "missing_data"
 
     def test_medication_exception_logic_uses_unknowns_and_explicit_allowances(self, client, db_session):
         _seed_trial_with_run(
@@ -886,10 +1061,17 @@ class TestPatientMatching:
 
         detail = client.get(f"/api/v1/matches/{result['id']}")
         assert detail.status_code == 200
+        payload = detail.json()
         outcomes = {
             item["criterion_text"]: item["outcome"]
-            for item in detail.json()["criteria"]
+            for item in payload["criteria"]
             if item["source_type"] == "extracted"
         }
         assert outcomes["Live-attenuated vaccine within 30 days before enrollment"] == "unknown"
         assert outcomes["Systemic corticosteroids except physiologic replacement doses"] == "not_triggered"
+        medication_gap = next(
+            item
+            for item in payload["gap_report"]["review_required"]
+            if item["criterion_text"] == "Live-attenuated vaccine within 30 days before enrollment"
+        )
+        assert medication_gap["kind"] == "review_required"

--- a/tests/unit/test_match_gap_report.py
+++ b/tests/unit/test_match_gap_report.py
@@ -1,0 +1,262 @@
+from types import SimpleNamespace
+
+from app.api.schemas import MatchGapReportResponse
+from app.matching.gap_report import build_gap_report_payload
+
+
+def _criterion(**overrides):
+    payload = {
+        "criterion_id": None,
+        "pipeline_run_id": None,
+        "source_label": "criterion",
+        "criterion_type": "inclusion",
+        "explanation_type": "criterion_unknown",
+        "outcome": "unknown",
+        "state": "structured_safe",
+        "state_reason": None,
+        "source_type": "extracted",
+        "category": "diagnosis",
+        "criterion_text": "Test criterion",
+        "explanation_text": "Available patient data is insufficient to evaluate this criterion safely.",
+        "evidence_payload": {"patient_conditions": []},
+    }
+    payload.update(overrides)
+    return SimpleNamespace(**payload)
+
+
+def test_gap_report_prioritizes_review_required_state_for_collapsed_unknowns():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="unknown",
+                state="review_required",
+                state_reason="review_required",
+                evidence_payload={
+                    "logic_group_id": "11111111-1111-1111-1111-111111111111",
+                    "logic_operator": "OR",
+                    "member_outcomes": ["unknown", "not_matched"],
+                    "member_states": ["review_required", "structured_safe"],
+                },
+            )
+        ]
+    ))
+
+    assert report.review_required[0].criterion_text == "Test criterion"
+    assert report.missing_data == []
+    assert report.hard_blockers == []
+    assert report.clarifiable_blockers == []
+
+
+def test_gap_report_keeps_low_confidence_extracted_sex_blockers_clarifiable():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="not_matched",
+                state="structured_low_confidence",
+                state_reason="low_confidence",
+                category="sex",
+                criterion_text="Male patients only",
+                evidence_payload={"patient_sex": "female"},
+            )
+        ]
+    ))
+
+    assert report.hard_blockers == []
+    assert len(report.clarifiable_blockers) == 1
+    assert report.clarifiable_blockers[0].category == "sex"
+
+
+def test_gap_report_does_not_relabel_legacy_unverifiable_unknowns_as_missing_data():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="unknown",
+                state="structured_low_confidence",
+                state_reason="legacy_state_unverifiable",
+                evidence_payload={"patient_conditions": []},
+            )
+        ]
+    ))
+
+    assert report.missing_data == []
+    assert len(report.review_required) == 1
+    assert report.review_required[0].state_reason == "legacy_state_unverifiable"
+
+
+def test_gap_report_preserves_requires_review_for_grouped_rows_with_snapshot_metadata():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="requires_review",
+                state="review_required",
+                state_reason="review_required:fuzzy_match",
+                evidence_payload={
+                    "review_reason": "fuzzy_match",
+                    "review_status": "pending",
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "11111111-1111-1111-1111-111111111111",
+                        "logic_operator": "OR",
+                    },
+                },
+            )
+        ]
+    ))
+
+    assert len(report.review_required) == 1
+    assert report.review_required[0].state_reason == "review_required"
+
+
+def test_gap_report_routes_ambiguous_unknowns_to_review_required_not_missing_data():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="unknown",
+                state="structured_low_confidence",
+                state_reason="low_confidence",
+                category="sex",
+                criterion_text="Participants of the appropriate sex may enroll",
+                evidence_payload={"patient_sex": "female"},
+                explanation_text="Available patient data is insufficient to evaluate this criterion safely.",
+            )
+        ]
+    ))
+
+    assert report.missing_data == []
+    assert len(report.review_required) == 1
+    assert report.review_required[0].category == "sex"
+
+
+def test_gap_report_routes_low_confidence_favorable_outcomes_to_review_required():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="matched",
+                state="structured_low_confidence",
+                state_reason="low_confidence",
+                category="diagnosis",
+                criterion_text="Metastatic breast cancer",
+                evidence_payload={"patient_conditions": [{"description": "Metastatic breast cancer"}]},
+            )
+        ]
+    ))
+
+    assert report.clarifiable_blockers == []
+    assert len(report.review_required) == 1
+    assert report.review_required[0].outcome == "matched"
+
+
+def test_grouped_or_unknown_preserves_review_required_signal_over_missing_data():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="unknown",
+                state="review_required",
+                state_reason="review_required",
+                category="diagnosis",
+                criterion_text="Metastatic melanoma",
+                evidence_payload={
+                    "patient_conditions": [],
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "33333333-3333-3333-3333-333333333333",
+                        "logic_operator": "OR",
+                    },
+                    "snapshot_missing_data": True,
+                    "member_criterion_texts": [
+                        "Metastatic melanoma",
+                        "Metastatic pancreatic cancer",
+                    ],
+                    "member_categories": ["diagnosis", "diagnosis"],
+                },
+            ),
+            _criterion(
+                outcome="unknown",
+                state="structured_safe",
+                state_reason=None,
+                category="diagnosis",
+                criterion_text="Metastatic pancreatic cancer",
+                evidence_payload={
+                    "patient_conditions": [],
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "33333333-3333-3333-3333-333333333333",
+                        "logic_operator": "OR",
+                    },
+                },
+            ),
+        ]
+    ))
+
+    assert report.missing_data == []
+    assert len(report.review_required) == 1
+    assert report.review_required[0].criterion_text == "Metastatic melanoma OR Metastatic pancreatic cancer"
+
+
+def test_grouped_or_mixed_categories_use_logic_group_category():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="not_matched",
+                state="structured_safe",
+                category="diagnosis",
+                criterion_text="Metastatic melanoma",
+                evidence_payload={
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "44444444-4444-4444-4444-444444444444",
+                        "logic_operator": "OR",
+                    },
+                    "member_criterion_texts": ["Metastatic melanoma", "BRAF V600E mutation"],
+                    "member_categories": ["diagnosis", "biomarker"],
+                },
+            ),
+            _criterion(
+                outcome="not_matched",
+                state="structured_safe",
+                category="biomarker",
+                criterion_text="BRAF V600E mutation",
+                evidence_payload={
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "44444444-4444-4444-4444-444444444444",
+                        "logic_operator": "OR",
+                    },
+                },
+            ),
+        ]
+    ))
+
+    assert len(report.hard_blockers) == 1
+    assert report.hard_blockers[0].category == "logic_group"
+
+
+def test_grouped_raw_items_collapse_without_order_dependence():
+    report = MatchGapReportResponse.model_validate(build_gap_report_payload(
+        [
+            _criterion(
+                outcome="requires_review",
+                state="review_required",
+                state_reason="review_required:fuzzy_match",
+                category="diagnosis",
+                criterion_text="Metastatic melanoma",
+                evidence_payload={
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "55555555-5555-5555-5555-555555555555",
+                        "logic_operator": "OR",
+                    }
+                },
+            ),
+            _criterion(
+                outcome="matched",
+                state="structured_safe",
+                category="diagnosis",
+                criterion_text="Metastatic breast cancer",
+                evidence_payload={
+                    "snapshot_match_metadata": {
+                        "logic_group_id": "55555555-5555-5555-5555-555555555555",
+                        "logic_operator": "OR",
+                    }
+                },
+            ),
+        ]
+    ))
+
+    assert report.review_required == []
+    assert report.hard_blockers == []
+    assert report.missing_data == []


### PR DESCRIPTION
## Summary
- add additive `gap_report` match-detail payload and frontend cards for hard blockers, clarifiable blockers, missing data, review-required items, and unsupported logic
- snapshot gap-report payloads at match time and backfill historical results conservatively with a migration-safe payload
- add regression coverage for OR-group semantics, low-confidence handling, historical fallback behavior, and gap bucket classification

## Test Plan
- [x] `./.ctm-dev/bin/ruff check app/api/routes/patients.py app/api/schemas.py app/matching/gap_report.py app/matching/service.py app/models/database.py tests/integration/test_patient_matching.py tests/unit/test_match_gap_report.py`
- [x] `./.ctm-dev/bin/pytest -q`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`
- [x] `./.hermes/scripts/pr_review_gate.sh main`

## Notes
- local review gate passed with report: `.hermes/reviews/2026-04-25_231307-feat-issue-10-structured-match-gap-reporting.md`
- PR-safe local summary draft: `.hermes/reviews/2026-04-25_231307-feat-issue-10-structured-match-gap-reporting.public-summary.md`

Closes #10
