### PR TITLE
feat: add extraction and matching coverage dashboard

### DIFF
--- a/app/api/routes/patients.py
+++ b/app/api/routes/patients.py
@@ -34,7 +34,7 @@ from app.api.schemas import (
 )
 from app.api.state import criterion_state_from_match_result_criterion, match_state_from_match_result
 from app.db.session import get_db
-from app.matching.gap_report import build_gap_report_payload
+from app.matching.gap_report import build_gap_report_payload, legacy_gap_report_payload
 from app.matching.service import CriterionEvaluation, PatientMatchService, _collapse_or_group
 from app.models.database import (
     MatchResult,
@@ -725,38 +725,7 @@ def _build_match_gap_report(criteria) -> MatchGapReportResponse:
 
 
 def _legacy_gap_report_payload(match_result: MatchResult) -> dict[str, list[dict[str, object | None]]]:
-    base_entry = {
-        "label": "Historical Snapshot",
-        "category": "historical_snapshot",
-        "criterion_text": "Gap report was not snapshotted for this historical match result.",
-        "state": match_result.state,
-        "state_reason": match_result.state_reason or "legacy_state_unverifiable",
-        "summary": match_result.summary_explanation,
-        "source_snippet": None,
-        "evidence_payload": None,
-    }
-    report = {
-        "hard_blockers": [],
-        "clarifiable_blockers": [],
-        "missing_data": [],
-        "review_required": [],
-        "unsupported": [],
-    }
-    if match_result.state == "blocked_unsupported":
-        report["unsupported"].append({**base_entry, "kind": "unsupported", "outcome": "unknown"})
-    if (
-        match_result.overall_status == "ineligible"
-        and match_result.unfavorable_count > 0
-        and match_result.state == "structured_safe"
-    ):
-        report["hard_blockers"].append({**base_entry, "kind": "hard_blocker", "outcome": "not_matched"})
-    if (
-        match_result.unknown_count > 0
-        or match_result.requires_review_count > 0
-        or (match_result.state not in {"structured_safe", "blocked_unsupported"})
-    ):
-        report["review_required"].append({**base_entry, "kind": "review_required", "outcome": "unknown"})
-    return report
+    return legacy_gap_report_payload(match_result)
 
 
 def _match_detail(match_result: MatchResult) -> MatchResultDetail:

--- a/app/api/routes/trials.py
+++ b/app/api/routes/trials.py
@@ -25,6 +25,7 @@ from app.api.schemas import (
     CriterionResponse,
     IngestRequest,
     IngestResponse,
+    PipelineCoverageResponse,
     PipelineRunListResponse,
     PipelineRunResponse,
     PipelineStatusResponse,
@@ -46,6 +47,7 @@ from app.fhir.mapper import FHIRMapper
 from app.fhir.models import ResearchStudy
 from app.ingestion.service import ExternalServiceValidationError, IngestionService
 from app.models.database import ExtractedCriterion, FHIRResearchStudy, PipelineRun, Trial
+from app.reporting.coverage_dashboard import build_pipeline_coverage_payload
 from app.time_utils import utc_now
 
 router = APIRouter()
@@ -446,6 +448,12 @@ def pipeline_status(request: Request, _: str = Depends(require_api_key), db: Ses
         total_criteria=total_criteria,
         review_pending=review_pending,
     )
+
+
+@router.get("/pipeline/coverage", response_model=PipelineCoverageResponse, responses=PROTECTED_READ_RESPONSES)
+def pipeline_coverage(request: Request, _: str = Depends(require_api_key), db: Session = Depends(get_db)):
+    add_request_log_context(request)
+    return PipelineCoverageResponse.model_validate(build_pipeline_coverage_payload(db))
 
 
 @router.get("/pipeline/runs", response_model=PipelineRunListResponse, responses=PROTECTED_READ_RESPONSES)

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -270,6 +270,81 @@ class PipelineStatusResponse(APIModel):
     review_pending: int
 
 
+class PipelineCoverageExtractionOverviewResponse(APIModel):
+    latest_run_trial_count: int
+    latest_run_criteria_count: int
+    review_pending_count: int
+    structured_safe_count: int
+    structured_low_confidence_count: int
+    review_required_count: int
+    blocked_unsupported_count: int
+
+
+class PipelineCoverageGapBucketCountsResponse(APIModel):
+    hard_blockers: int
+    clarifiable_blockers: int
+    missing_data: int
+    review_required: int
+    unsupported: int
+
+
+class PipelineCoverageMatchingOverviewResponse(APIModel):
+    total_match_results: int
+    persisted_gap_report_count: int
+    legacy_match_count: int
+    status_breakdown: dict[str, int]
+    gap_bucket_counts: PipelineCoverageGapBucketCountsResponse
+
+
+class CuratedCorpusFixtureCoverageResponse(APIModel):
+    fixture: str
+    criteria_count: int
+    review_required_count: int
+    review_reasons: dict[str, int]
+    structurally_exportable_fhir_count: int
+    uncoded_but_accepted_count: int
+    medication_statement_projected_count: int
+    blocked_missing_rxnorm_count: int
+    blocked_missing_class_code_count: int
+    blocked_missing_class_code_terms: dict[str, int]
+    review_required_ambiguous_class_count: int
+    category_distribution: dict[str, int]
+    projection_status_distribution: dict[str, int]
+
+
+class CuratedCorpusSummaryCoverageResponse(APIModel):
+    fixture_count: int
+    criteria_count: int
+    review_required_count: int
+    structurally_exportable_fhir_count: int
+    medication_statement_projected_count: int
+    blocked_missing_rxnorm_count: int
+    blocked_missing_class_code_count: int
+    blocked_missing_class_code_terms: dict[str, int]
+    review_required_ambiguous_class_count: int
+    uncoded_but_accepted_count: int
+    category_distribution: dict[str, int]
+    review_reasons: dict[str, int]
+
+
+class CuratedCorpusMetadataResponse(APIModel):
+    generated_at: datetime | None = None
+    generator: str | None = None
+    fixture_names: list[str]
+    source: str
+
+
+class PipelineCoverageResponse(APIModel):
+    extraction_overview: PipelineCoverageExtractionOverviewResponse
+    review_reason_breakdown: dict[str, int]
+    blocked_criteria_breakdown: dict[str, int]
+    matching_overview: PipelineCoverageMatchingOverviewResponse
+    curated_corpus_metadata: CuratedCorpusMetadataResponse
+    curated_corpus_summary: CuratedCorpusSummaryCoverageResponse
+    curated_corpus_fixtures: list[CuratedCorpusFixtureCoverageResponse]
+    notes: list[str]
+
+
 class PipelineRunResponse(APIModel):
     id: UUID
     trial_id: UUID

--- a/app/matching/gap_report.py
+++ b/app/matching/gap_report.py
@@ -289,3 +289,41 @@ def build_gap_report_payload(items: list[Any]) -> dict[str, list[dict[str, Any]]
         if state == "structured_low_confidence" and outcome in {"matched", "not_triggered"}:
             report["review_required"].append(_build_entry(item, "review_required"))
     return report
+
+
+def legacy_gap_report_payload(match_result) -> dict[str, list[dict[str, object | None]]]:
+    unknown_count = getattr(match_result, "unknown_count", None) or 0
+    requires_review_count = getattr(match_result, "requires_review_count", None) or 0
+    unfavorable_count = getattr(match_result, "unfavorable_count", None) or 0
+    base_entry = {
+        "label": "Historical Snapshot",
+        "category": "historical_snapshot",
+        "criterion_text": "Gap report was not snapshotted for this historical match result.",
+        "state": match_result.state,
+        "state_reason": match_result.state_reason or "legacy_state_unverifiable",
+        "summary": match_result.summary_explanation,
+        "source_snippet": None,
+        "evidence_payload": None,
+    }
+    report = {
+        "hard_blockers": [],
+        "clarifiable_blockers": [],
+        "missing_data": [],
+        "review_required": [],
+        "unsupported": [],
+    }
+    if match_result.state == "blocked_unsupported":
+        report["unsupported"].append({**base_entry, "kind": "unsupported", "outcome": "unknown"})
+    if (
+        match_result.overall_status == "ineligible"
+        and unfavorable_count > 0
+        and match_result.state == "structured_safe"
+    ):
+        report["hard_blockers"].append({**base_entry, "kind": "hard_blocker", "outcome": "not_matched"})
+    if (
+        unknown_count > 0
+        or requires_review_count > 0
+        or (match_result.state not in {"structured_safe", "blocked_unsupported"})
+    ):
+        report["review_required"].append({**base_entry, "kind": "review_required", "outcome": "unknown"})
+    return report

--- a/app/reporting/assets/curated_corpus_coverage_snapshot.json
+++ b/app/reporting/assets/curated_corpus_coverage_snapshot.json
@@ -1,0 +1,172 @@
+{
+  "fixtures": [
+    {
+      "blocked_missing_class_code_count": 1,
+      "blocked_missing_class_code_terms": {
+        "agent targeting kras": 1
+      },
+      "blocked_missing_rxnorm_count": 0,
+      "category_distribution": {
+        "cns_metastases": 1,
+        "diagnosis": 4,
+        "prior_therapy": 2,
+        "procedural_requirement": 2
+      },
+      "criteria_count": 9,
+      "fixture": "therapy_class_and_procedures",
+      "medication_statement_projected_count": 1,
+      "projection_status_distribution": {
+        "blocked_missing_class_code": 1,
+        "projected": 1
+      },
+      "review_reasons": {},
+      "review_required_ambiguous_class_count": 0,
+      "review_required_count": 0,
+      "structurally_exportable_fhir_count": 2,
+      "uncoded_but_accepted_count": 9
+    },
+    {
+      "blocked_missing_class_code_count": 1,
+      "blocked_missing_class_code_terms": {
+        "cyp3a4 inhibitors inducers": 1
+      },
+      "blocked_missing_rxnorm_count": 0,
+      "category_distribution": {
+        "concomitant_medication": 3
+      },
+      "criteria_count": 3,
+      "fixture": "medication_exception_logic",
+      "medication_statement_projected_count": 7,
+      "projection_status_distribution": {
+        "blocked_missing_class_code": 1,
+        "projected": 7
+      },
+      "review_reasons": {},
+      "review_required_ambiguous_class_count": 0,
+      "review_required_count": 0,
+      "structurally_exportable_fhir_count": 0,
+      "uncoded_but_accepted_count": 3
+    },
+    {
+      "blocked_missing_class_code_count": 1,
+      "blocked_missing_class_code_terms": {
+        "cyp3a4 inhibitors inducers": 1
+      },
+      "blocked_missing_rxnorm_count": 0,
+      "category_distribution": {
+        "concomitant_medication": 1
+      },
+      "criteria_count": 1,
+      "fixture": "nct07084584_cyp3a4_exception",
+      "medication_statement_projected_count": 4,
+      "projection_status_distribution": {
+        "blocked_missing_class_code": 1,
+        "projected": 4
+      },
+      "review_reasons": {},
+      "review_required_ambiguous_class_count": 0,
+      "review_required_count": 0,
+      "structurally_exportable_fhir_count": 0,
+      "uncoded_but_accepted_count": 1
+    },
+    {
+      "blocked_missing_class_code_count": 1,
+      "blocked_missing_class_code_terms": {
+        "cyp3a4 inhibitors inducers": 1
+      },
+      "blocked_missing_rxnorm_count": 0,
+      "category_distribution": {
+        "concomitant_medication": 1
+      },
+      "criteria_count": 1,
+      "fixture": "nct03872596_cyp3a4_washout",
+      "medication_statement_projected_count": 0,
+      "projection_status_distribution": {
+        "blocked_missing_class_code": 1
+      },
+      "review_reasons": {
+        "complex_criteria": 1
+      },
+      "review_required_ambiguous_class_count": 0,
+      "review_required_count": 1,
+      "structurally_exportable_fhir_count": 0,
+      "uncoded_but_accepted_count": 0
+    },
+    {
+      "blocked_missing_class_code_count": 0,
+      "blocked_missing_class_code_terms": {},
+      "blocked_missing_rxnorm_count": 0,
+      "category_distribution": {
+        "biomarker": 1,
+        "diagnosis": 1
+      },
+      "criteria_count": 2,
+      "fixture": "nct05346328_stage_biomarker",
+      "medication_statement_projected_count": 0,
+      "projection_status_distribution": {},
+      "review_reasons": {},
+      "review_required_ambiguous_class_count": 0,
+      "review_required_count": 0,
+      "structurally_exportable_fhir_count": 1,
+      "uncoded_but_accepted_count": 2
+    },
+    {
+      "blocked_missing_class_code_count": 0,
+      "blocked_missing_class_code_terms": {},
+      "blocked_missing_rxnorm_count": 0,
+      "category_distribution": {
+        "prior_therapy": 2
+      },
+      "criteria_count": 2,
+      "fixture": "nct05346328_line_of_therapy",
+      "medication_statement_projected_count": 2,
+      "projection_status_distribution": {
+        "projected": 2
+      },
+      "review_reasons": {},
+      "review_required_ambiguous_class_count": 0,
+      "review_required_count": 0,
+      "structurally_exportable_fhir_count": 2,
+      "uncoded_but_accepted_count": 2
+    }
+  ],
+  "metadata": {
+    "fixture_names": [
+      "therapy_class_and_procedures",
+      "medication_exception_logic",
+      "nct07084584_cyp3a4_exception",
+      "nct03872596_cyp3a4_washout",
+      "nct05346328_stage_biomarker",
+      "nct05346328_line_of_therapy"
+    ],
+    "generated_at": "2026-04-26T04:21:18.312594Z",
+    "generator": "app.scripts.curated_corpus_report.build_curated_corpus_report",
+    "source": "checked_in_snapshot"
+  },
+  "summary": {
+    "blocked_missing_class_code_count": 4,
+    "blocked_missing_class_code_terms": {
+      "agent targeting kras": 1,
+      "cyp3a4 inhibitors inducers": 3
+    },
+    "blocked_missing_rxnorm_count": 0,
+    "category_distribution": {
+      "biomarker": 1,
+      "cns_metastases": 1,
+      "concomitant_medication": 5,
+      "diagnosis": 5,
+      "prior_therapy": 4,
+      "procedural_requirement": 2
+    },
+    "criteria_count": 18,
+    "fixture_count": 6,
+    "medication_statement_projected_count": 14,
+    "review_reasons": {
+      "complex_criteria": 1
+    },
+    "review_required_ambiguous_class_count": 0,
+    "review_required_count": 1,
+    "structurally_exportable_fhir_count": 5,
+    "uncoded_but_accepted_count": 17
+  }
+}

--- a/app/reporting/coverage_dashboard.py
+++ b/app/reporting/coverage_dashboard.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    CuratedCorpusFixtureCoverageResponse,
+    CuratedCorpusMetadataResponse,
+    CuratedCorpusSummaryCoverageResponse,
+)
+from app.api.state import criterion_state_from_extracted
+from app.matching.gap_report import legacy_gap_report_payload
+from app.models.database import ExtractedCriterion, MatchResult, MatchRun, PipelineRun
+
+COVERAGE_NOTES = [
+    "Coverage metrics are operational quality signals for extraction and matching, not clinical performance claims.",
+    "Review-required and blocked counts are safety indicators to prioritize, not debt to hide.",
+    "Historical rows outside the latest per-patient match snapshot are excluded to avoid drift in coverage totals.",
+]
+CURATED_CORPUS_SNAPSHOT_PATH = Path(__file__).resolve().parent / "assets" / "curated_corpus_coverage_snapshot.json"
+REQUIRED_CURATED_SNAPSHOT_KEYS = {"metadata", "summary", "fixtures"}
+
+
+def _latest_completed_runs_subquery():
+    ranked_runs = (
+        select(
+            PipelineRun.id.label("id"),
+            PipelineRun.trial_id.label("trial_id"),
+            func.row_number()
+            .over(
+                partition_by=PipelineRun.trial_id,
+                order_by=(
+                    PipelineRun.finished_at.desc().nullslast(),
+                    PipelineRun.started_at.desc(),
+                    PipelineRun.id.desc(),
+                ),
+            )
+            .label("run_rank"),
+        )
+        .where(PipelineRun.status == "completed")
+        .subquery()
+    )
+    return select(ranked_runs.c.id, ranked_runs.c.trial_id).where(ranked_runs.c.run_rank == 1)
+
+
+def _latest_completed_match_run_ids_subquery():
+    ranked_runs = (
+        select(
+            MatchRun.id.label("id"),
+            MatchRun.patient_id.label("patient_id"),
+            func.row_number()
+            .over(
+                partition_by=MatchRun.patient_id,
+                order_by=(
+                    MatchRun.completed_at.desc(),
+                    MatchRun.created_at.desc(),
+                    MatchRun.id.desc(),
+                ),
+            )
+            .label("run_rank"),
+        )
+        .where(MatchRun.status == "completed")
+        .subquery()
+    )
+    return select(ranked_runs.c.id, ranked_runs.c.patient_id).where(ranked_runs.c.run_rank == 1)
+
+
+def _empty_curated_corpus_snapshot() -> dict[str, Any]:
+    return {
+        "metadata": {
+            "generated_at": None,
+            "generator": None,
+            "fixture_names": [],
+            "source": "unavailable",
+        },
+        "summary": {
+            "fixture_count": 0,
+            "criteria_count": 0,
+            "review_required_count": 0,
+            "structurally_exportable_fhir_count": 0,
+            "medication_statement_projected_count": 0,
+            "blocked_missing_rxnorm_count": 0,
+            "blocked_missing_class_code_count": 0,
+            "blocked_missing_class_code_terms": {},
+            "review_required_ambiguous_class_count": 0,
+            "uncoded_but_accepted_count": 0,
+            "category_distribution": {},
+            "review_reasons": {},
+        },
+        "fixtures": [],
+    }
+
+
+def _load_curated_corpus_snapshot() -> tuple[dict[str, Any], bool]:
+    if not CURATED_CORPUS_SNAPSHOT_PATH.exists():
+        return _empty_curated_corpus_snapshot(), False
+    try:
+        payload = json.loads(CURATED_CORPUS_SNAPSHOT_PATH.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return _empty_curated_corpus_snapshot(), False
+    if not isinstance(payload, dict) or not REQUIRED_CURATED_SNAPSHOT_KEYS <= set(payload):
+        return _empty_curated_corpus_snapshot(), False
+    try:
+        metadata = CuratedCorpusMetadataResponse.model_validate(payload.get("metadata")).model_dump(mode="json")
+        summary = CuratedCorpusSummaryCoverageResponse.model_validate(payload.get("summary")).model_dump(mode="json")
+        fixtures = [
+            CuratedCorpusFixtureCoverageResponse.model_validate(item).model_dump(mode="json")
+            for item in payload.get("fixtures", [])
+        ]
+    except Exception:
+        return _empty_curated_corpus_snapshot(), False
+    return {
+        "metadata": metadata,
+        "summary": summary,
+        "fixtures": fixtures,
+    }, True
+
+
+def _build_extraction_overview(
+    criteria_rows: list[tuple[str, bool, str | None, str | None, float | None]],
+    latest_run_trial_count: int,
+) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
+    state_counts: Counter[str] = Counter()
+    review_reason_breakdown: Counter[str] = Counter()
+    blocked_criteria_breakdown: Counter[str] = Counter()
+
+    for category, review_required, review_reason, review_status, confidence in criteria_rows:
+        criterion = SimpleNamespace(
+            category=category,
+            review_required=review_required,
+            review_reason=review_reason,
+            review_status=review_status,
+            confidence=confidence,
+        )
+        state, _ = criterion_state_from_extracted(criterion)
+        state_counts[state] += 1
+        if review_required and review_status == "pending":
+            review_reason_breakdown[review_reason or "unspecified"] += 1
+        if state == "blocked_unsupported":
+            blocked_criteria_breakdown[category] += 1
+
+    extraction_overview = {
+        "latest_run_trial_count": latest_run_trial_count,
+        "latest_run_criteria_count": len(criteria_rows),
+        "review_pending_count": sum(review_reason_breakdown.values()),
+        "structured_safe_count": state_counts["structured_safe"],
+        "structured_low_confidence_count": state_counts["structured_low_confidence"],
+        "review_required_count": state_counts["review_required"],
+        "blocked_unsupported_count": state_counts["blocked_unsupported"],
+    }
+    return (
+        extraction_overview,
+        dict(sorted(review_reason_breakdown.items())),
+        dict(sorted(blocked_criteria_breakdown.items())),
+    )
+
+
+def _build_matching_overview(
+    match_rows: list[
+        tuple[
+            str,
+            dict[str, Any] | None,
+            str,
+            str | None,
+            int,
+            int,
+            int,
+            str | None,
+        ]
+    ]
+) -> dict[str, Any]:
+    status_breakdown: Counter[str] = Counter()
+    gap_bucket_counts: Counter[str] = Counter()
+    persisted_gap_report_count = 0
+    legacy_match_count = 0
+
+    for (
+        overall_status,
+        payload,
+        state,
+        state_reason,
+        unknown_count,
+        requires_review_count,
+        unfavorable_count,
+        summary_explanation,
+    ) in match_rows:
+        status_breakdown[overall_status] += 1
+        if isinstance(payload, dict):
+            persisted_gap_report_count += 1
+            effective_payload = payload
+        else:
+            legacy_match_count += 1
+            effective_payload = legacy_gap_report_payload(
+                SimpleNamespace(
+                    overall_status=overall_status,
+                    state=state,
+                    state_reason=state_reason,
+                    unknown_count=unknown_count,
+                    requires_review_count=requires_review_count,
+                    unfavorable_count=unfavorable_count,
+                    summary_explanation=summary_explanation,
+                )
+            )
+        for bucket in (
+            "hard_blockers",
+            "clarifiable_blockers",
+            "missing_data",
+            "review_required",
+            "unsupported",
+        ):
+            gap_bucket_counts[bucket] += len(effective_payload.get(bucket) or [])
+
+    return {
+        "total_match_results": len(match_rows),
+        "persisted_gap_report_count": persisted_gap_report_count,
+        "legacy_match_count": legacy_match_count,
+        "status_breakdown": dict(sorted(status_breakdown.items())),
+        "gap_bucket_counts": {
+            "hard_blockers": gap_bucket_counts["hard_blockers"],
+            "clarifiable_blockers": gap_bucket_counts["clarifiable_blockers"],
+            "missing_data": gap_bucket_counts["missing_data"],
+            "review_required": gap_bucket_counts["review_required"],
+            "unsupported": gap_bucket_counts["unsupported"],
+        },
+    }
+
+
+def build_pipeline_coverage_payload(db: Session) -> dict[str, Any]:
+    latest_runs_subquery = _latest_completed_runs_subquery().subquery()
+    criteria_rows = (
+        db.query(
+            ExtractedCriterion.category,
+            ExtractedCriterion.review_required,
+            ExtractedCriterion.review_reason,
+            ExtractedCriterion.review_status,
+            ExtractedCriterion.confidence,
+        )
+        .filter(ExtractedCriterion.pipeline_run_id.in_(select(latest_runs_subquery.c.id)))
+        .all()
+    )
+    latest_run_trial_count = db.query(latest_runs_subquery.c.trial_id).count()
+    extraction_overview, review_reason_breakdown, blocked_criteria_breakdown = _build_extraction_overview(
+        criteria_rows,
+        latest_run_trial_count,
+    )
+
+    latest_match_runs_subquery = _latest_completed_match_run_ids_subquery().subquery()
+    match_rows = (
+        db.query(
+            MatchResult.overall_status,
+            MatchResult.gap_report_payload,
+            MatchResult.state,
+            MatchResult.state_reason,
+            MatchResult.unknown_count,
+            MatchResult.requires_review_count,
+            MatchResult.unfavorable_count,
+            MatchResult.summary_explanation,
+        )
+        .filter(MatchResult.match_run_id.in_(select(latest_match_runs_subquery.c.id)))
+        .all()
+    )
+    curated_report, curated_snapshot_available = _load_curated_corpus_snapshot()
+    notes = list(COVERAGE_NOTES)
+    if not curated_snapshot_available:
+        notes.append(
+            "Curated corpus snapshot is unavailable in this runtime,"
+            " so fixture coverage is omitted instead of recomputing it live."
+        )
+    return {
+        "extraction_overview": extraction_overview,
+        "review_reason_breakdown": review_reason_breakdown,
+        "blocked_criteria_breakdown": blocked_criteria_breakdown,
+        "matching_overview": _build_matching_overview(match_rows),
+        "curated_corpus_metadata": curated_report["metadata"],
+        "curated_corpus_summary": curated_report["summary"],
+        "curated_corpus_fixtures": curated_report["fixtures"],
+        "notes": notes,
+    }

--- a/frontend/src/app/coverage/page.tsx
+++ b/frontend/src/app/coverage/page.tsx
@@ -1,0 +1,191 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/page-header";
+import { Panel } from "@/components/panel";
+import { StatGrid } from "@/components/stat-grid";
+import { ctmApi } from "@/lib/api/client";
+
+export const dynamic = "force-dynamic";
+
+function renderBreakdownEntries(breakdown: Record<string, number>) {
+  const entries = Object.entries(breakdown);
+  if (!entries.length) {
+    return <p className="text-sm leading-7 text-ink/68">No items in this bucket yet.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.map(([label, value]) => (
+        <div key={label} className="flex items-center justify-between gap-4 rounded-3xl bg-sand/70 px-4 py-3">
+          <p className="text-sm text-ink/72">{label.replaceAll("_", " ")}</p>
+          <p className="text-sm font-semibold text-ink">{value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default async function CoveragePage() {
+  const coverage = await ctmApi.getPipelineCoverage();
+
+  return (
+    <>
+      <PageHeader
+        label="Coverage Dashboard"
+        title="Track extraction and matching coverage without hiding uncertainty."
+        description="This is an internal evaluation lens: it shows where the system is confidently structured, where review load remains high, and where persisted match-gap reporting is already available."
+        actions={
+          <>
+            <Link className="rounded-full bg-ink px-5 py-3 text-sm font-semibold text-sand" href="/pipeline">
+              Back to pipeline
+            </Link>
+            <Link className="rounded-full border border-ink/15 px-5 py-3 text-sm font-semibold text-ink" href="/review">
+              Open review queue
+            </Link>
+          </>
+        }
+      />
+
+      <StatGrid
+        items={[
+          {
+            label: "Latest-run criteria",
+            value: coverage.extraction_overview.latest_run_criteria_count,
+            detail: `${coverage.extraction_overview.latest_run_trial_count} trials in current extraction snapshot`
+          },
+          {
+            label: "Review pending",
+            value: coverage.extraction_overview.review_pending_count,
+            detail: `${coverage.extraction_overview.review_required_count} review-required criteria overall`
+          },
+          {
+            label: "Persisted gap reports",
+            value: coverage.matching_overview.persisted_gap_report_count,
+            detail: `${coverage.matching_overview.legacy_match_count} historical match results still conservative`
+          },
+          {
+            label: "Curated fixtures",
+            value: coverage.curated_corpus_summary.fixture_count,
+            detail: `${coverage.curated_corpus_summary.criteria_count} representative criteria across the fixture set`
+          }
+        ]}
+      />
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Panel title="Extraction confidence snapshot" eyebrow="Current latest-run state">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Structured safe</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.extraction_overview.structured_safe_count}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Low confidence</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.extraction_overview.structured_low_confidence_count}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Review required</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.extraction_overview.review_required_count}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Unsupported</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.extraction_overview.blocked_unsupported_count}</p>
+            </div>
+          </div>
+        </Panel>
+
+        <Panel title="Match coverage snapshot" eyebrow="Persisted gap-report availability">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Eligible / possible / ineligible</p>
+              <p className="mt-2 text-lg font-semibold text-ink">
+                {coverage.matching_overview.status_breakdown.eligible ?? 0} / {coverage.matching_overview.status_breakdown.possible ?? 0} / {coverage.matching_overview.status_breakdown.ineligible ?? 0}
+              </p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Total match results</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.matching_overview.total_match_results}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Missing-data gaps</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.matching_overview.gap_bucket_counts.missing_data}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Review-required gaps</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.matching_overview.gap_bucket_counts.review_required}</p>
+            </div>
+          </div>
+        </Panel>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+        <Panel title="Review reason pressure" eyebrow="Why humans are still needed">{renderBreakdownEntries(coverage.review_reason_breakdown)}</Panel>
+        <Panel title="Blocked criteria pressure" eyebrow="Where extraction still exits the safe lane">
+          {renderBreakdownEntries(coverage.blocked_criteria_breakdown)}
+        </Panel>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <Panel title="Curated corpus summary" eyebrow="Regression-friendly fixture slice">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Criteria</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.curated_corpus_summary.criteria_count}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Review required</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.curated_corpus_summary.review_required_count}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">FHIR exportable</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.curated_corpus_summary.structurally_exportable_fhir_count}</p>
+            </div>
+            <div className="rounded-3xl bg-sand/70 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-ink/45">Medication projections</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{coverage.curated_corpus_summary.medication_statement_projected_count}</p>
+            </div>
+          </div>
+          <p className="mt-4 text-sm leading-7 text-ink/68">
+            The curated fixture set is useful for showing directional improvement over time, but it is still a representative internal corpus rather than a public benchmark.
+          </p>
+        </Panel>
+
+        <Panel title="Coverage interpretation guardrails" eyebrow="Read this before overclaiming">
+          <div className="space-y-3">
+            <div className="rounded-3xl bg-sand/70 p-4 text-sm leading-7 text-ink/72">
+              Curated corpus source: {coverage.curated_corpus_metadata.source}
+              {coverage.curated_corpus_metadata.generated_at
+                ? ` · generated ${coverage.curated_corpus_metadata.generated_at}`
+                : " · snapshot unavailable in this runtime"}
+            </div>
+            {coverage.notes.map((note) => (
+              <div key={note} className="rounded-3xl bg-sand/70 p-4 text-sm leading-7 text-ink/72">
+                {note}
+              </div>
+            ))}
+          </div>
+        </Panel>
+      </div>
+
+      <Panel title="Fixture-level detail" eyebrow="What the representative corpus currently looks like">
+        <div className="grid gap-4 lg:grid-cols-2">
+          {coverage.curated_corpus_fixtures.map((fixture) => (
+            <article key={fixture.fixture} className="rounded-3xl border border-ink/8 bg-sand/55 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-sm font-semibold text-ink">{fixture.fixture.replaceAll("_", " ")}</p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.22em] text-ink/45">
+                    {fixture.criteria_count} criteria · {fixture.review_required_count} review-required
+                  </p>
+                </div>
+                <p className="text-sm font-semibold text-ink">{fixture.medication_statement_projected_count} projected</p>
+              </div>
+              <p className="mt-4 text-sm leading-7 text-ink/68">
+                Missing class-code blockers: {fixture.blocked_missing_class_code_count} · ambiguous classes: {fixture.review_required_ambiguous_class_count}
+              </p>
+            </article>
+          ))}
+        </div>
+      </Panel>
+    </>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Route } from "next";
 
 import { PageHeader } from "@/components/page-header";
 import { Panel } from "@/components/panel";
@@ -28,6 +29,9 @@ export default async function HomePage() {
           <>
             <Link className="rounded-full bg-ink px-5 py-3 text-sm font-semibold text-sand" href="/pipeline">
               Start in pipeline
+            </Link>
+            <Link className="rounded-full border border-ink/15 px-5 py-3 text-sm font-semibold text-ink" href={"/coverage" as Route}>
+              View coverage
             </Link>
             <Link className="rounded-full border border-ink/15 px-5 py-3 text-sm font-semibold text-ink" href="/patients">
               Intake patient

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Route } from "next";
 
 import { ingestTrialAction, searchIngestAction } from "@/app/actions";
 import { PageHeader } from "@/components/page-header";
@@ -49,6 +50,9 @@ export default async function PipelinePage({
           <>
             <Link className="rounded-full bg-ink px-5 py-3 text-sm font-semibold text-sand" href="/review">
               Open review queue
+            </Link>
+            <Link className="rounded-full border border-ink/15 px-5 py-3 text-sm font-semibold text-ink" href={"/coverage" as Route}>
+              Coverage dashboard
             </Link>
             <Link className="rounded-full border border-ink/15 px-5 py-3 text-sm font-semibold text-ink" href="/trials">
               Browse trials

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -13,6 +13,7 @@ import type {
   PatientCreatePayload,
   PatientDetail,
   PatientListResponse,
+  PipelineCoverageResponse,
   PipelineRunListResponse,
   PipelineStatusResponse,
   ReviewQueueResponse,
@@ -82,6 +83,7 @@ export const ctmApi = {
     }),
   getReviewQueue: (query = "") => apiRequest<ReviewQueueResponse>(`/review${query}`, { auth: true }),
   getPipelineStatus: () => apiRequest<PipelineStatusResponse>("/pipeline/status", { auth: true }),
+  getPipelineCoverage: () => apiRequest<PipelineCoverageResponse>("/pipeline/coverage", { auth: true }),
   listPipelineRuns: (query = "") =>
     apiRequest<PipelineRunListResponse>(`/pipeline/runs${query}`, { auth: true }),
   listPatients: (query = "") => apiRequest<PatientListResponse>(`/patients${query}`, { auth: true }),

--- a/frontend/src/lib/api/openapi.json
+++ b/frontend/src/lib/api/openapi.json
@@ -1059,6 +1059,215 @@
         "title": "CriterionResponse",
         "type": "object"
       },
+      "CuratedCorpusFixtureCoverageResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "blocked_missing_class_code_count": {
+            "title": "Blocked Missing Class Code Count",
+            "type": "integer"
+          },
+          "blocked_missing_class_code_terms": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Blocked Missing Class Code Terms",
+            "type": "object"
+          },
+          "blocked_missing_rxnorm_count": {
+            "title": "Blocked Missing Rxnorm Count",
+            "type": "integer"
+          },
+          "category_distribution": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Category Distribution",
+            "type": "object"
+          },
+          "criteria_count": {
+            "title": "Criteria Count",
+            "type": "integer"
+          },
+          "fixture": {
+            "title": "Fixture",
+            "type": "string"
+          },
+          "medication_statement_projected_count": {
+            "title": "Medication Statement Projected Count",
+            "type": "integer"
+          },
+          "projection_status_distribution": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Projection Status Distribution",
+            "type": "object"
+          },
+          "review_reasons": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Review Reasons",
+            "type": "object"
+          },
+          "review_required_ambiguous_class_count": {
+            "title": "Review Required Ambiguous Class Count",
+            "type": "integer"
+          },
+          "review_required_count": {
+            "title": "Review Required Count",
+            "type": "integer"
+          },
+          "structurally_exportable_fhir_count": {
+            "title": "Structurally Exportable Fhir Count",
+            "type": "integer"
+          },
+          "uncoded_but_accepted_count": {
+            "title": "Uncoded But Accepted Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fixture",
+          "criteria_count",
+          "review_required_count",
+          "review_reasons",
+          "structurally_exportable_fhir_count",
+          "uncoded_but_accepted_count",
+          "medication_statement_projected_count",
+          "blocked_missing_rxnorm_count",
+          "blocked_missing_class_code_count",
+          "blocked_missing_class_code_terms",
+          "review_required_ambiguous_class_count",
+          "category_distribution",
+          "projection_status_distribution"
+        ],
+        "title": "CuratedCorpusFixtureCoverageResponse",
+        "type": "object"
+      },
+      "CuratedCorpusMetadataResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "fixture_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Fixture Names",
+            "type": "array"
+          },
+          "generated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generated At"
+          },
+          "generator": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generator"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "fixture_names",
+          "source"
+        ],
+        "title": "CuratedCorpusMetadataResponse",
+        "type": "object"
+      },
+      "CuratedCorpusSummaryCoverageResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "blocked_missing_class_code_count": {
+            "title": "Blocked Missing Class Code Count",
+            "type": "integer"
+          },
+          "blocked_missing_class_code_terms": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Blocked Missing Class Code Terms",
+            "type": "object"
+          },
+          "blocked_missing_rxnorm_count": {
+            "title": "Blocked Missing Rxnorm Count",
+            "type": "integer"
+          },
+          "category_distribution": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Category Distribution",
+            "type": "object"
+          },
+          "criteria_count": {
+            "title": "Criteria Count",
+            "type": "integer"
+          },
+          "fixture_count": {
+            "title": "Fixture Count",
+            "type": "integer"
+          },
+          "medication_statement_projected_count": {
+            "title": "Medication Statement Projected Count",
+            "type": "integer"
+          },
+          "review_reasons": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Review Reasons",
+            "type": "object"
+          },
+          "review_required_ambiguous_class_count": {
+            "title": "Review Required Ambiguous Class Count",
+            "type": "integer"
+          },
+          "review_required_count": {
+            "title": "Review Required Count",
+            "type": "integer"
+          },
+          "structurally_exportable_fhir_count": {
+            "title": "Structurally Exportable Fhir Count",
+            "type": "integer"
+          },
+          "uncoded_but_accepted_count": {
+            "title": "Uncoded But Accepted Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fixture_count",
+          "criteria_count",
+          "review_required_count",
+          "structurally_exportable_fhir_count",
+          "medication_statement_projected_count",
+          "blocked_missing_rxnorm_count",
+          "blocked_missing_class_code_count",
+          "blocked_missing_class_code_terms",
+          "review_required_ambiguous_class_count",
+          "uncoded_but_accepted_count",
+          "category_distribution",
+          "review_reasons"
+        ],
+        "title": "CuratedCorpusSummaryCoverageResponse",
+        "type": "object"
+      },
       "ErrorResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3389,6 +3598,177 @@
         "title": "PatientUpdateRequest",
         "type": "object"
       },
+      "PipelineCoverageExtractionOverviewResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "blocked_unsupported_count": {
+            "title": "Blocked Unsupported Count",
+            "type": "integer"
+          },
+          "latest_run_criteria_count": {
+            "title": "Latest Run Criteria Count",
+            "type": "integer"
+          },
+          "latest_run_trial_count": {
+            "title": "Latest Run Trial Count",
+            "type": "integer"
+          },
+          "review_pending_count": {
+            "title": "Review Pending Count",
+            "type": "integer"
+          },
+          "review_required_count": {
+            "title": "Review Required Count",
+            "type": "integer"
+          },
+          "structured_low_confidence_count": {
+            "title": "Structured Low Confidence Count",
+            "type": "integer"
+          },
+          "structured_safe_count": {
+            "title": "Structured Safe Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "latest_run_trial_count",
+          "latest_run_criteria_count",
+          "review_pending_count",
+          "structured_safe_count",
+          "structured_low_confidence_count",
+          "review_required_count",
+          "blocked_unsupported_count"
+        ],
+        "title": "PipelineCoverageExtractionOverviewResponse",
+        "type": "object"
+      },
+      "PipelineCoverageGapBucketCountsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "clarifiable_blockers": {
+            "title": "Clarifiable Blockers",
+            "type": "integer"
+          },
+          "hard_blockers": {
+            "title": "Hard Blockers",
+            "type": "integer"
+          },
+          "missing_data": {
+            "title": "Missing Data",
+            "type": "integer"
+          },
+          "review_required": {
+            "title": "Review Required",
+            "type": "integer"
+          },
+          "unsupported": {
+            "title": "Unsupported",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "hard_blockers",
+          "clarifiable_blockers",
+          "missing_data",
+          "review_required",
+          "unsupported"
+        ],
+        "title": "PipelineCoverageGapBucketCountsResponse",
+        "type": "object"
+      },
+      "PipelineCoverageMatchingOverviewResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "gap_bucket_counts": {
+            "$ref": "#/components/schemas/PipelineCoverageGapBucketCountsResponse"
+          },
+          "legacy_match_count": {
+            "title": "Legacy Match Count",
+            "type": "integer"
+          },
+          "persisted_gap_report_count": {
+            "title": "Persisted Gap Report Count",
+            "type": "integer"
+          },
+          "status_breakdown": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Status Breakdown",
+            "type": "object"
+          },
+          "total_match_results": {
+            "title": "Total Match Results",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_match_results",
+          "persisted_gap_report_count",
+          "legacy_match_count",
+          "status_breakdown",
+          "gap_bucket_counts"
+        ],
+        "title": "PipelineCoverageMatchingOverviewResponse",
+        "type": "object"
+      },
+      "PipelineCoverageResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "blocked_criteria_breakdown": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Blocked Criteria Breakdown",
+            "type": "object"
+          },
+          "curated_corpus_fixtures": {
+            "items": {
+              "$ref": "#/components/schemas/CuratedCorpusFixtureCoverageResponse"
+            },
+            "title": "Curated Corpus Fixtures",
+            "type": "array"
+          },
+          "curated_corpus_metadata": {
+            "$ref": "#/components/schemas/CuratedCorpusMetadataResponse"
+          },
+          "curated_corpus_summary": {
+            "$ref": "#/components/schemas/CuratedCorpusSummaryCoverageResponse"
+          },
+          "extraction_overview": {
+            "$ref": "#/components/schemas/PipelineCoverageExtractionOverviewResponse"
+          },
+          "matching_overview": {
+            "$ref": "#/components/schemas/PipelineCoverageMatchingOverviewResponse"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Notes",
+            "type": "array"
+          },
+          "review_reason_breakdown": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Review Reason Breakdown",
+            "type": "object"
+          }
+        },
+        "required": [
+          "extraction_overview",
+          "review_reason_breakdown",
+          "blocked_criteria_breakdown",
+          "matching_overview",
+          "curated_corpus_metadata",
+          "curated_corpus_summary",
+          "curated_corpus_fixtures",
+          "notes"
+        ],
+        "title": "PipelineCoverageResponse",
+        "type": "object"
+      },
       "PipelineRunListResponse": {
         "additionalProperties": false,
         "properties": {
@@ -5153,6 +5533,59 @@
           }
         ],
         "summary": "List Patient Matches"
+      }
+    },
+    "/api/v1/pipeline/coverage": {
+      "get": {
+        "operationId": "pipeline_coverage_api_v1_pipeline_coverage_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PipelineCoverageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "invalid_api_key",
+                  "detail": "Valid X-API-Key header required",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API key"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "internal_server_error",
+                  "detail": "Internal server error",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unhandled server error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Pipeline Coverage"
       }
     },
     "/api/v1/pipeline/runs": {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -163,6 +163,81 @@ export type PipelineStatusResponse = {
   review_pending: number;
 };
 
+export type PipelineCoverageExtractionOverview = {
+  latest_run_trial_count: number;
+  latest_run_criteria_count: number;
+  review_pending_count: number;
+  structured_safe_count: number;
+  structured_low_confidence_count: number;
+  review_required_count: number;
+  blocked_unsupported_count: number;
+};
+
+export type PipelineCoverageGapBucketCounts = {
+  hard_blockers: number;
+  clarifiable_blockers: number;
+  missing_data: number;
+  review_required: number;
+  unsupported: number;
+};
+
+export type PipelineCoverageMatchingOverview = {
+  total_match_results: number;
+  persisted_gap_report_count: number;
+  legacy_match_count: number;
+  status_breakdown: Record<string, number>;
+  gap_bucket_counts: PipelineCoverageGapBucketCounts;
+};
+
+export type CuratedCorpusFixtureCoverage = {
+  fixture: string;
+  criteria_count: number;
+  review_required_count: number;
+  review_reasons: Record<string, number>;
+  structurally_exportable_fhir_count: number;
+  uncoded_but_accepted_count: number;
+  medication_statement_projected_count: number;
+  blocked_missing_rxnorm_count: number;
+  blocked_missing_class_code_count: number;
+  blocked_missing_class_code_terms: Record<string, number>;
+  review_required_ambiguous_class_count: number;
+  category_distribution: Record<string, number>;
+  projection_status_distribution: Record<string, number>;
+};
+
+export type CuratedCorpusSummaryCoverage = {
+  fixture_count: number;
+  criteria_count: number;
+  review_required_count: number;
+  structurally_exportable_fhir_count: number;
+  medication_statement_projected_count: number;
+  blocked_missing_rxnorm_count: number;
+  blocked_missing_class_code_count: number;
+  blocked_missing_class_code_terms: Record<string, number>;
+  review_required_ambiguous_class_count: number;
+  uncoded_but_accepted_count: number;
+  category_distribution: Record<string, number>;
+  review_reasons: Record<string, number>;
+};
+
+export type CuratedCorpusMetadata = {
+  generated_at?: string | null;
+  generator?: string | null;
+  fixture_names: string[];
+  source: string;
+};
+
+export type PipelineCoverageResponse = {
+  extraction_overview: PipelineCoverageExtractionOverview;
+  review_reason_breakdown: Record<string, number>;
+  blocked_criteria_breakdown: Record<string, number>;
+  matching_overview: PipelineCoverageMatchingOverview;
+  curated_corpus_metadata: CuratedCorpusMetadata;
+  curated_corpus_summary: CuratedCorpusSummaryCoverage;
+  curated_corpus_fixtures: CuratedCorpusFixtureCoverage[];
+  notes: string[];
+};
+
 export type PipelineRunResponse = {
   id: string;
   trial_id: string;

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -13,7 +13,7 @@ from app.config import settings
 from app.db.session import get_db
 from app.ingestion.service import ExternalServiceValidationError, SearchIngestBatchResult, SearchIngestTrialResult
 from app.main import app
-from app.models.database import ExtractedCriterion, PipelineRun, Trial
+from app.models.database import ExtractedCriterion, MatchResult, MatchRun, Patient, PipelineRun, Trial
 from app.scripts.seed import sync_coding_lookups
 
 MOCK_DIR = Path(__file__).parent.parent / "fixtures" / "mock_ctgov_responses"
@@ -53,6 +53,7 @@ class TestRouteRegistration:
             assert "/api/v1/review" in paths
             assert "/api/v1/criteria/{criterion_id}/review" in paths
             assert "/api/v1/pipeline/status" in paths
+            assert "/api/v1/pipeline/coverage" in paths
             assert "/api/v1/pipeline/runs" in paths
             assert "/api/v1/pipeline/runs/{run_id}" in paths
             assert "/api/v1/trials/{trial_id}/re-extract" in paths
@@ -266,6 +267,119 @@ def _add_completed_run(db_session, trial, criteria_payloads):
 
     db_session.commit()
     return run, created
+
+
+def _seed_match_results_for_coverage(db_session, primary_trial):
+    secondary_trial, _, _, _ = _seed_trial(db_session, conditions=["Melanoma"])
+    tertiary_trial, _, _, _ = _seed_trial(db_session, conditions=["Lung Cancer"])
+
+    patient = Patient(external_id=f"coverage-patient-{uuid.uuid4().hex[:8]}")
+    db_session.add(patient)
+    db_session.flush()
+
+    match_run = MatchRun(
+        patient_id=patient.id,
+        status="completed",
+        total_trials_evaluated=3,
+        eligible_trials=1,
+        possible_trials=1,
+        ineligible_trials=1,
+    )
+    db_session.add(match_run)
+    db_session.flush()
+
+    db_session.add_all(
+        [
+            MatchResult(
+                match_run_id=match_run.id,
+                patient_id=patient.id,
+                trial_id=primary_trial.id,
+                overall_status="eligible",
+                score=0.91,
+                favorable_count=2,
+                unfavorable_count=0,
+                unknown_count=0,
+                requires_review_count=0,
+                summary_explanation="Eligible match",
+                gap_report_payload={
+                    "hard_blockers": [],
+                    "clarifiable_blockers": [],
+                    "missing_data": [],
+                    "review_required": [],
+                    "unsupported": [],
+                },
+                state="structured_safe",
+            ),
+            MatchResult(
+                match_run_id=match_run.id,
+                patient_id=patient.id,
+                trial_id=secondary_trial.id,
+                overall_status="possible",
+                score=0.42,
+                favorable_count=1,
+                unfavorable_count=0,
+                unknown_count=1,
+                requires_review_count=1,
+                summary_explanation="Possible match",
+                gap_report_payload={
+                    "hard_blockers": [],
+                    "clarifiable_blockers": [],
+                    "missing_data": [
+                        {
+                            "kind": "missing_data",
+                            "label": "Age",
+                            "category": "age",
+                            "criterion_text": "Age >= 18 years",
+                            "outcome": "unknown",
+                            "state": "review_required",
+                            "state_reason": "review_required:missing_age",
+                            "summary": "Missing age",
+                            "source_snippet": None,
+                            "evidence_payload": {"snapshot_missing_data": True},
+                        }
+                    ],
+                    "review_required": [
+                        {
+                            "kind": "review_required",
+                            "label": "Diagnosis",
+                            "category": "diagnosis",
+                            "criterion_text": "Histologically confirmed melanoma",
+                            "outcome": "unknown",
+                            "state": "review_required",
+                            "state_reason": "legacy_state_unverifiable",
+                            "summary": "Historical uncertainty",
+                            "source_snippet": None,
+                            "evidence_payload": {},
+                        }
+                    ],
+                    "unsupported": [],
+                },
+                state="review_required",
+                state_reason="review_required",
+            ),
+            MatchResult(
+                match_run_id=match_run.id,
+                patient_id=patient.id,
+                trial_id=tertiary_trial.id,
+                overall_status="ineligible",
+                score=0.11,
+                favorable_count=0,
+                unfavorable_count=2,
+                unknown_count=0,
+                requires_review_count=0,
+                summary_explanation="Ineligible match",
+                gap_report_payload=None,
+                state="blocked_unsupported",
+                state_reason="blocked_unsupported",
+            ),
+        ]
+    )
+    db_session.commit()
+    return {
+        "patient": patient,
+        "secondary_trial": secondary_trial,
+        "tertiary_trial": tertiary_trial,
+    }
 
 
 @pytestmark_docker
@@ -951,6 +1065,187 @@ class TestPipelineEndpoints:
         assert data["total_trials"] == baseline_data["total_trials"]
         assert data["total_criteria"] == baseline_data["total_criteria"] - 1
         assert data["review_pending"] == baseline_data["review_pending"] - 1
+
+    def test_pipeline_coverage_summarizes_extraction_and_matching_metrics(self, client, db_session):
+        trial, _, _, _ = _seed_trial(db_session)
+        baseline = client.get("/api/v1/pipeline/coverage")
+        assert baseline.status_code == 200
+        baseline_data = baseline.json()
+        no_completed_trial = Trial(
+            nct_id=f"NCT{uuid.uuid4().hex[:8].upper()}",
+            raw_json={"protocolSection": {"eligibilityModule": {"eligibilityCriteria": "Age >= 18"}}},
+            content_hash="no_completed_run_hash",
+            brief_title="Trial without completed run",
+            status="RECRUITING",
+        )
+        db_session.add(no_completed_trial)
+        db_session.commit()
+        _add_completed_run(
+            db_session,
+            trial,
+            [
+                {
+                    "type": "inclusion",
+                    "category": "diagnosis",
+                    "original_text": "Histologically confirmed melanoma",
+                    "review_required": True,
+                    "review_reason": "manual_review_needed",
+                    "review_status": "pending",
+                    "confidence": 0.88,
+                },
+                {
+                    "type": "exclusion",
+                    "category": "biomarker",
+                    "original_text": "No EGFR exon 19 deletion",
+                    "review_required": False,
+                    "review_status": "rejected",
+                    "confidence": 0.97,
+                },
+                {
+                    "type": "inclusion",
+                    "category": "age",
+                    "original_text": "Age >= 18 years",
+                    "review_required": False,
+                    "confidence": 0.2,
+                },
+            ],
+        )
+        seeded_match_resources = _seed_match_results_for_coverage(db_session, trial)
+
+        response = client.get("/api/v1/pipeline/coverage")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["extraction_overview"]["latest_run_trial_count"] == (
+            baseline_data["extraction_overview"]["latest_run_trial_count"] + 2
+        )
+        assert data["extraction_overview"]["structured_safe_count"] >= 1
+        assert data["extraction_overview"]["structured_low_confidence_count"] >= 1
+        assert data["extraction_overview"]["review_required_count"] >= 1
+        assert data["extraction_overview"]["blocked_unsupported_count"] >= 1
+        assert data["review_reason_breakdown"]["manual_review_needed"] >= 1
+        assert data["blocked_criteria_breakdown"]["biomarker"] >= 1
+        assert data["matching_overview"]["total_match_results"] >= 3
+        assert data["matching_overview"]["status_breakdown"]["eligible"] >= 1
+        assert data["matching_overview"]["status_breakdown"]["possible"] >= 1
+        assert data["matching_overview"]["status_breakdown"]["ineligible"] >= 1
+        assert data["matching_overview"]["persisted_gap_report_count"] >= 2
+        assert data["matching_overview"]["legacy_match_count"] >= 1
+        assert data["matching_overview"]["gap_bucket_counts"]["missing_data"] >= 1
+        assert data["matching_overview"]["gap_bucket_counts"]["review_required"] >= 1
+        assert data["curated_corpus_metadata"]["source"] == "checked_in_snapshot"
+        assert data["curated_corpus_summary"]["fixture_count"] >= 1
+        assert "coverage metrics" in data["notes"][0].lower()
+
+        db_session.delete(seeded_match_resources["patient"])
+        db_session.delete(seeded_match_resources["secondary_trial"])
+        db_session.delete(seeded_match_resources["tertiary_trial"])
+        db_session.delete(no_completed_trial)
+        db_session.commit()
+
+    def test_pipeline_coverage_uses_latest_match_run_per_patient_snapshot(self, client, db_session):
+        baseline = client.get("/api/v1/pipeline/coverage")
+        assert baseline.status_code == 200
+        baseline_data = baseline.json()
+        trial, _, _, _ = _seed_trial(db_session)
+        patient = Patient(external_id=f"snapshot-patient-{uuid.uuid4().hex[:8]}")
+        db_session.add(patient)
+        db_session.flush()
+
+        older_run = MatchRun(
+            patient_id=patient.id,
+            status="completed",
+            total_trials_evaluated=1,
+            eligible_trials=1,
+            possible_trials=0,
+            ineligible_trials=0,
+        )
+        db_session.add(older_run)
+        db_session.flush()
+        db_session.add(
+            MatchResult(
+                match_run_id=older_run.id,
+                patient_id=patient.id,
+                trial_id=trial.id,
+                overall_status="eligible",
+                score=0.9,
+                favorable_count=1,
+                unfavorable_count=0,
+                unknown_count=0,
+                requires_review_count=0,
+                gap_report_payload={
+                    "hard_blockers": [],
+                    "clarifiable_blockers": [],
+                    "missing_data": [],
+                    "review_required": [],
+                    "unsupported": [],
+                },
+                state="structured_safe",
+            )
+        )
+        db_session.flush()
+
+        latest_run = MatchRun(
+            patient_id=patient.id,
+            status="completed",
+            total_trials_evaluated=1,
+            eligible_trials=0,
+            possible_trials=1,
+            ineligible_trials=0,
+        )
+        db_session.add(latest_run)
+        db_session.flush()
+        db_session.add(
+            MatchResult(
+                match_run_id=latest_run.id,
+                patient_id=patient.id,
+                trial_id=trial.id,
+                overall_status="possible",
+                score=0.4,
+                favorable_count=0,
+                unfavorable_count=0,
+                unknown_count=1,
+                requires_review_count=1,
+                gap_report_payload={
+                    "hard_blockers": [],
+                    "clarifiable_blockers": [],
+                    "missing_data": [],
+                    "review_required": [
+                        {
+                            "kind": "review_required",
+                            "label": "Diagnosis",
+                            "category": "diagnosis",
+                            "criterion_text": "Metastatic breast cancer",
+                            "outcome": "unknown",
+                            "state": "review_required",
+                            "state_reason": "review_required:manual_review_needed",
+                            "summary": "Needs review",
+                            "source_snippet": None,
+                            "evidence_payload": {},
+                        }
+                    ],
+                    "unsupported": [],
+                },
+                state="review_required",
+                state_reason="review_required",
+            )
+        )
+        db_session.commit()
+
+        response = client.get("/api/v1/pipeline/coverage")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["matching_overview"]["total_match_results"] == (
+            baseline_data["matching_overview"]["total_match_results"] + 1
+        )
+        assert data["matching_overview"]["status_breakdown"]["possible"] >= (
+            baseline_data["matching_overview"]["status_breakdown"].get("possible", 0) + 1
+        )
+
+        db_session.delete(patient)
+        db_session.delete(trial)
+        db_session.commit()
 
     def test_list_pipeline_runs(self, client, db_session):
         _seed_trial(db_session)

--- a/tests/unit/test_coverage_dashboard.py
+++ b/tests/unit/test_coverage_dashboard.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+from app.reporting import coverage_dashboard
+from app.scripts.curated_corpus_report import build_curated_corpus_report
+
+
+def test_load_curated_corpus_snapshot_returns_empty_payload_when_artifact_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        coverage_dashboard,
+        "CURATED_CORPUS_SNAPSHOT_PATH",
+        Path(tmp_path) / "missing-curated-corpus-snapshot.json",
+    )
+
+    snapshot, available = coverage_dashboard._load_curated_corpus_snapshot()
+
+    assert available is False
+    assert snapshot["metadata"]["source"] == "unavailable"
+    assert snapshot["summary"]["fixture_count"] == 0
+    assert snapshot["summary"]["criteria_count"] == 0
+    assert snapshot["fixtures"] == []
+
+
+def test_load_curated_corpus_snapshot_returns_empty_payload_when_json_is_malformed(monkeypatch, tmp_path):
+    malformed_path = Path(tmp_path) / "curated-corpus-coverage-snapshot.json"
+    malformed_path.write_text("{not valid json")
+    monkeypatch.setattr(coverage_dashboard, "CURATED_CORPUS_SNAPSHOT_PATH", malformed_path)
+
+    snapshot, available = coverage_dashboard._load_curated_corpus_snapshot()
+
+    assert available is False
+    assert snapshot["metadata"]["source"] == "unavailable"
+    assert snapshot["fixtures"] == []
+
+
+def test_load_curated_corpus_snapshot_returns_empty_payload_when_shape_is_invalid(monkeypatch, tmp_path):
+    invalid_path = Path(tmp_path) / "curated-corpus-coverage-snapshot.json"
+    invalid_path.write_text('{"metadata": {}, "summary": {}, "fixtures": []}')
+    monkeypatch.setattr(coverage_dashboard, "CURATED_CORPUS_SNAPSHOT_PATH", invalid_path)
+
+    snapshot, available = coverage_dashboard._load_curated_corpus_snapshot()
+
+    assert available is False
+    assert snapshot["metadata"]["source"] == "unavailable"
+
+
+def test_checked_in_curated_corpus_snapshot_has_provenance_metadata():
+    snapshot, available = coverage_dashboard._load_curated_corpus_snapshot()
+
+    assert available is True
+    assert snapshot["metadata"]["source"] == "checked_in_snapshot"
+    assert snapshot["metadata"]["generator"] == "app.scripts.curated_corpus_report.build_curated_corpus_report"
+    assert snapshot["metadata"]["generated_at"]
+    assert snapshot["metadata"]["fixture_names"]
+    assert snapshot["summary"]["fixture_count"] == len(snapshot["fixtures"])
+
+
+def test_checked_in_curated_corpus_snapshot_matches_current_curated_report():
+    snapshot, available = coverage_dashboard._load_curated_corpus_snapshot()
+
+    assert available is True
+    current_report = build_curated_corpus_report(snapshot["metadata"]["fixture_names"])
+    assert snapshot["summary"] == current_report["summary"]
+    assert snapshot["fixtures"] == current_report["fixtures"]
+
+
+def test_legacy_gap_report_payload_handles_null_counts():
+    report = coverage_dashboard.legacy_gap_report_payload(
+        type(
+            "HistoricalMatchResult",
+            (),
+            {
+                "overall_status": "possible",
+                "state": "review_required",
+                "state_reason": None,
+                "unknown_count": None,
+                "requires_review_count": None,
+                "unfavorable_count": None,
+                "summary_explanation": "Historical uncertainty",
+            },
+        )()
+    )
+
+    assert report["review_required"]


### PR DESCRIPTION
## Summary
- add a protected `/api/v1/pipeline/coverage` endpoint for extraction and matching coverage metrics
- add a `/coverage` dashboard page linked from the command surface and pipeline page
- serve curated corpus coverage from a runtime-safe checked-in snapshot with provenance metadata and fallback behavior

## What this adds
- latest extraction snapshot metrics from completed pipeline runs
- latest-per-patient matching snapshot metrics from completed match runs
- blocked/review-required breakdowns for operational coverage tracking
- curated corpus summary + fixture detail for representative regression visibility
- historical-match fallback handling that stays conservative when persisted gap reports are unavailable

## Commit structure
- `ad2e10a` `feat: add extraction and matching coverage dashboard`
- `74dbf94` `fix: share legacy gap-report fallback semantics`

## Why the later fix commit exists
The second commit captures issues that resurfaced during later local review-gate iterations:
- shared historical gap-report fallback reuse
- null-safe legacy match-count handling
- tighter snapshot robustness around curated corpus reporting

## Verification
- local PR review gate: pass
- changed-file Ruff: pass
- backend pytest: 394 passed
- frontend typecheck: pass
- frontend build: pass

Closes #17
