### PR TITLE
feat: add human review queue for match follow-ups

### DIFF
--- a/app/api/routes/trials.py
+++ b/app/api/routes/trials.py
@@ -25,6 +25,8 @@ from app.api.schemas import (
     CriterionResponse,
     IngestRequest,
     IngestResponse,
+    MatchReviewQueueItemResponse,
+    MatchReviewQueueResponse,
     PipelineCoverageResponse,
     PipelineRunListResponse,
     PipelineRunResponse,
@@ -46,7 +48,7 @@ from app.fhir.criterion_projection import CriterionProjectionMapper
 from app.fhir.mapper import FHIRMapper
 from app.fhir.models import ResearchStudy
 from app.ingestion.service import ExternalServiceValidationError, IngestionService
-from app.models.database import ExtractedCriterion, FHIRResearchStudy, PipelineRun, Trial
+from app.models.database import ExtractedCriterion, FHIRResearchStudy, MatchReviewItem, MatchRun, PipelineRun, Trial
 from app.reporting.coverage_dashboard import build_pipeline_coverage_payload
 from app.time_utils import utc_now
 
@@ -67,7 +69,6 @@ reextract_rate_limit = rate_limit_dependency(
     limit_setting="reextract_rate_limit_requests",
     window_setting="reextract_rate_limit_window_seconds",
 )
-
 
 def _get_ingestion_service(request: Request, db: Session = Depends(get_db)) -> IngestionService:
     pipeline = getattr(request.app.state, "extraction_pipeline", None)
@@ -352,7 +353,12 @@ def get_review_queue(
         query = query.filter(ExtractedCriterion.trial_id == trial_id)
 
     total = query.count()
-    criteria = query.order_by(ExtractedCriterion.created_at.asc()).offset((page - 1) * per_page).limit(per_page).all()
+    criteria = (
+        query.order_by(ExtractedCriterion.created_at.asc(), ExtractedCriterion.id.asc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+        .all()
+    )
 
     breakdown_query = (
         db.query(ExtractedCriterion.review_reason, func.count(ExtractedCriterion.id))
@@ -366,8 +372,10 @@ def get_review_queue(
         breakdown_query = breakdown_query.filter(ExtractedCriterion.review_reason == reason)
     if trial_id:
         breakdown_query = breakdown_query.filter(ExtractedCriterion.trial_id == trial_id)
-    breakdown_query = breakdown_query.group_by(ExtractedCriterion.review_reason)
-    breakdown_by_reason = {row[0] or "unknown": row[1] for row in breakdown_query.all()}
+    breakdown_by_reason = {
+        (row[0] or "unknown"): row[1]
+        for row in breakdown_query.group_by(ExtractedCriterion.review_reason).all()
+    }
 
     return ReviewQueueResponse(
         items=[_criterion_detail(c) for c in criteria],
@@ -375,6 +383,65 @@ def get_review_queue(
         page=page,
         per_page=per_page,
         breakdown_by_reason=breakdown_by_reason,
+    )
+
+
+@router.get("/review/matches", response_model=MatchReviewQueueResponse, responses=PROTECTED_READ_RESPONSES)
+def get_match_review_queue(
+    request: Request,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    reason: str | None = None,
+    trial_id: UUID | None = None,
+    patient_id: UUID | None = None,
+    _: str = Depends(require_api_key),
+    db: Session = Depends(get_db),
+):
+    add_request_log_context(request, trial_id=trial_id)
+    latest_runs = _latest_completed_match_run_ids_subquery().subquery()
+    query = (
+        db.query(MatchReviewItem, Trial)
+        .join(Trial, Trial.id == MatchReviewItem.trial_id)
+        .filter(MatchReviewItem.match_run_id.in_(select(latest_runs.c.id)))
+    )
+    if reason:
+        query = query.filter(MatchReviewItem.reason_code == reason)
+    if trial_id:
+        query = query.filter(MatchReviewItem.trial_id == trial_id)
+    if patient_id:
+        query = query.filter(MatchReviewItem.patient_id == patient_id)
+
+    total = query.count()
+    rows = (
+        query.order_by(MatchReviewItem.created_at.asc(), MatchReviewItem.id.asc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+        .all()
+    )
+
+    breakdown_query = (
+        db.query(MatchReviewItem.reason_code, func.count(MatchReviewItem.id))
+        .filter(MatchReviewItem.match_run_id.in_(select(latest_runs.c.id)))
+    )
+    if reason:
+        breakdown_query = breakdown_query.filter(MatchReviewItem.reason_code == reason)
+    if trial_id:
+        breakdown_query = breakdown_query.filter(MatchReviewItem.trial_id == trial_id)
+    if patient_id:
+        breakdown_query = breakdown_query.filter(MatchReviewItem.patient_id == patient_id)
+    breakdown_rows = (
+        breakdown_query.group_by(MatchReviewItem.reason_code)
+        .order_by(MatchReviewItem.reason_code.asc())
+        .all()
+    )
+
+    return MatchReviewQueueResponse(
+        items=[_match_review_queue_item_from_model(item, trial) for item, trial in rows],
+        total=total,
+        page=page,
+        per_page=per_page,
+        breakdown_by_reason={str(reason_code or "unknown"): count for reason_code, count in breakdown_rows},
+        breakdown_scope="filtered",
     )
 
 
@@ -520,6 +587,55 @@ def re_extract_trial(
         review_count=result.review_count,
         diff_summary=result.diff_summary,
     )
+
+
+def _match_review_queue_item_from_model(item: MatchReviewItem, trial: Trial) -> MatchReviewQueueItemResponse:
+    return MatchReviewQueueItemResponse(
+        id=str(item.id),
+        kind="match_review_item",
+        reason_code=item.reason_code,
+        reason_codes=[item.reason_code],
+        trial_id=item.trial_id,
+        trial_nct_id=trial.nct_id,
+        trial_brief_title=trial.brief_title,
+        patient_id=item.patient_id,
+        match_run_id=item.match_run_id,
+        match_result_id=item.match_result_id,
+        bucket=item.bucket,
+        category=item.category,
+        original_text=item.criterion_text,
+        outcome=item.outcome,
+        state=item.state,
+        state_reason=item.state_reason,
+        review_required=item.bucket == "review_required",
+        review_reason=item.reason_code,
+        review_status="pending" if item.bucket == "review_required" else None,
+        source_snippet=item.source_snippet,
+        evidence_payload=item.evidence_payload,
+        created_at=item.created_at,
+    )
+
+
+def _latest_completed_match_run_ids_subquery():
+    ranked_runs = (
+        select(
+            MatchRun.id.label("id"),
+            MatchRun.patient_id.label("patient_id"),
+            func.row_number()
+            .over(
+                partition_by=MatchRun.patient_id,
+                order_by=(
+                    MatchRun.completed_at.desc(),
+                    MatchRun.created_at.desc(),
+                    MatchRun.id.desc(),
+                ),
+            )
+            .label("run_rank"),
+        )
+        .where(MatchRun.status == "completed")
+        .subquery()
+    )
+    return select(ranked_runs.c.id, ranked_runs.c.patient_id).where(ranked_runs.c.run_rank == 1)
 
 
 def _get_trial_or_404(trial_id: UUID, db: Session) -> Trial:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -228,12 +228,46 @@ class CriteriaListResponse(APIModel):
     per_page: int
 
 
+class MatchReviewQueueItemResponse(APIModel):
+    id: str
+    kind: Literal["match_review_item"] = "match_review_item"
+    reason_code: str | None = None
+    reason_codes: list[str] = Field(default_factory=list)
+    trial_id: UUID
+    trial_nct_id: str
+    trial_brief_title: str
+    patient_id: UUID
+    match_run_id: UUID
+    match_result_id: UUID
+    bucket: Literal["review_required", "missing_data", "clarifiable_blockers", "unsupported"]
+    category: str
+    original_text: str
+    outcome: str | None = None
+    state: ConfidenceState
+    state_reason: str | None = None
+    review_required: bool
+    review_reason: str | None = None
+    review_status: str | None = None
+    source_snippet: str | None = None
+    evidence_payload: dict[str, Any] | None = None
+    created_at: datetime | None = None
+
+
 class ReviewQueueResponse(APIModel):
     items: list[CriterionResponse]
     total: int
     page: int
     per_page: int
     breakdown_by_reason: dict[str, int]
+
+
+class MatchReviewQueueResponse(APIModel):
+    items: list[MatchReviewQueueItemResponse]
+    total: int
+    page: int
+    per_page: int
+    breakdown_by_reason: dict[str, int]
+    breakdown_scope: Literal["filtered"] = "filtered"
 
 
 class CriterionFHIRProjectionResponse(APIModel):

--- a/app/db/migrations/versions/0009_add_match_review_items.py
+++ b/app/db/migrations/versions/0009_add_match_review_items.py
@@ -1,0 +1,242 @@
+"""add match review items
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-04-29 00:00:00.000000
+
+"""
+
+import hashlib
+import json
+import uuid
+from typing import Any, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0009"
+down_revision: Union[str, None] = "0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FOLLOW_UP_BUCKETS = ("review_required", "missing_data", "clarifiable_blockers", "unsupported")
+
+
+def _string_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _item_key(*, bucket: str, ordinal: int, category: str, criterion_text: str, reason_code: str) -> str:
+    digest_source = "\0".join([category, criterion_text, reason_code])
+    digest = hashlib.sha1(digest_source.encode("utf-8")).hexdigest()[:12]
+    return f"{bucket}:{ordinal}:{digest}"
+
+
+def _review_item_rows(row) -> list[dict[str, Any]]:
+    payload = row["gap_report_payload"] if isinstance(row["gap_report_payload"], dict) else None
+    rows: list[dict[str, Any]] = []
+    if payload is not None:
+        for bucket in FOLLOW_UP_BUCKETS:
+            entries = payload.get(bucket, [])
+            if not isinstance(entries, list):
+                continue
+            for ordinal, entry in enumerate(entries):
+                if not isinstance(entry, dict):
+                    continue
+                category = _string_value(entry.get("category")) or "logic_group"
+                criterion_text = _string_value(entry.get("criterion_text")) or ""
+                reason_code = (
+                    _string_value(entry.get("state_reason"))
+                    or _string_value(entry.get("kind"))
+                    or bucket
+                )
+                rows.append(
+                    {
+                        "id": uuid.uuid4(),
+                        "match_result_id": row["id"],
+                        "match_run_id": row["match_run_id"],
+                        "patient_id": row["patient_id"],
+                        "trial_id": row["trial_id"],
+                        "item_key": _item_key(
+                            bucket=bucket,
+                            ordinal=ordinal,
+                            category=category,
+                            criterion_text=criterion_text,
+                            reason_code=reason_code,
+                        ),
+                        "bucket": bucket,
+                        "reason_code": reason_code,
+                        "category": category,
+                        "criterion_text": criterion_text,
+                        "outcome": _string_value(entry.get("outcome")),
+                        "state": _string_value(entry.get("state")) or "review_required",
+                        "state_reason": _string_value(entry.get("state_reason")),
+                        "source_snippet": _string_value(entry.get("source_snippet")),
+                        "evidence_payload": (
+                            json.dumps(entry.get("evidence_payload"))
+                            if isinstance(entry.get("evidence_payload"), dict)
+                            else None
+                        ),
+                        "summary": _string_value(entry.get("summary")),
+                        "created_at": row["created_at"],
+                    }
+                )
+    if rows:
+        return rows
+
+    state = _string_value(row["state"]) or "review_required"
+    unresolved = (
+        (row["unknown_count"] or 0) > 0
+        or (row["requires_review_count"] or 0) > 0
+        or state not in {"structured_safe", "blocked_unsupported"}
+        or state == "blocked_unsupported"
+    )
+    if not unresolved:
+        return []
+
+    bucket = "unsupported" if state == "blocked_unsupported" else "review_required"
+    reason_code = _string_value(row["state_reason"]) or "legacy_state_unverifiable"
+    criterion_text = "Gap report was not snapshotted for this historical match result."
+    return [
+        {
+            "id": uuid.uuid4(),
+            "match_result_id": row["id"],
+            "match_run_id": row["match_run_id"],
+            "patient_id": row["patient_id"],
+            "trial_id": row["trial_id"],
+            "item_key": _item_key(
+                bucket=bucket,
+                ordinal=0,
+                category="historical_snapshot",
+                criterion_text=criterion_text,
+                reason_code=reason_code,
+            ),
+            "bucket": bucket,
+            "reason_code": reason_code,
+            "category": "historical_snapshot",
+            "criterion_text": criterion_text,
+            "outcome": "unknown",
+            "state": state,
+            "state_reason": reason_code,
+            "source_snippet": None,
+            "evidence_payload": None,
+            "summary": row["summary_explanation"],
+            "created_at": row["created_at"],
+        }
+    ]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "match_review_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("match_result_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("match_run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("patient_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("trial_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("item_key", sa.String(), nullable=False),
+        sa.Column("bucket", sa.String(), nullable=False),
+        sa.Column("reason_code", sa.String(), nullable=False),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("criterion_text", sa.Text(), nullable=False),
+        sa.Column("outcome", sa.String(), nullable=True),
+        sa.Column("state", sa.String(), nullable=False),
+        sa.Column("state_reason", sa.String(), nullable=True),
+        sa.Column("source_snippet", sa.Text(), nullable=True),
+        sa.Column("evidence_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["match_result_id"], ["match_results.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["match_run_id"], ["match_runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["trial_id"], ["trials.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("match_result_id", "item_key", name="uq_match_review_item_result_key"),
+    )
+    op.create_index("ix_match_review_items_match_result_id", "match_review_items", ["match_result_id"])
+    op.create_index("ix_match_review_items_match_run_id", "match_review_items", ["match_run_id"])
+    op.create_index("ix_match_review_items_patient_id", "match_review_items", ["patient_id"])
+    op.create_index("ix_match_review_items_trial_id", "match_review_items", ["trial_id"])
+    op.create_index("ix_match_review_items_bucket", "match_review_items", ["bucket"])
+    op.create_index("ix_match_review_items_reason_code", "match_review_items", ["reason_code"])
+    op.create_index("ix_match_review_items_queue", "match_review_items", ["bucket", "reason_code", "created_at"])
+
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text(
+            """
+            SELECT
+                id,
+                match_run_id,
+                patient_id,
+                trial_id,
+                overall_status,
+                unknown_count,
+                requires_review_count,
+                state,
+                state_reason,
+                summary_explanation,
+                gap_report_payload,
+                created_at
+            FROM match_results
+            """
+        )
+    ).mappings()
+
+    backfill_rows = []
+    for row in rows:
+        backfill_rows.extend(_review_item_rows(row))
+
+    if backfill_rows:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO match_review_items (
+                    id,
+                    match_result_id,
+                    match_run_id,
+                    patient_id,
+                    trial_id,
+                    item_key,
+                    bucket,
+                    reason_code,
+                    category,
+                    criterion_text,
+                    outcome,
+                    state,
+                    state_reason,
+                    source_snippet,
+                    evidence_payload,
+                    summary,
+                    created_at
+                ) VALUES (
+                    :id,
+                    :match_result_id,
+                    :match_run_id,
+                    :patient_id,
+                    :trial_id,
+                    :item_key,
+                    :bucket,
+                    :reason_code,
+                    :category,
+                    :criterion_text,
+                    :outcome,
+                    :state,
+                    :state_reason,
+                    :source_snippet,
+                    CAST(:evidence_payload AS JSONB),
+                    :summary,
+                    :created_at
+                )
+                """
+            ),
+            backfill_rows,
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("match_review_items")

--- a/app/matching/review_items.py
+++ b/app/matching/review_items.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+FOLLOW_UP_BUCKETS = ("review_required", "missing_data", "clarifiable_blockers", "unsupported")
+
+
+@dataclass(frozen=True)
+class MatchReviewItemSnapshot:
+    item_key: str
+    bucket: str
+    reason_code: str
+    category: str
+    criterion_text: str
+    outcome: str | None
+    state: str
+    state_reason: str | None
+    source_snippet: str | None
+    evidence_payload: dict[str, Any] | None
+    summary: str | None
+
+
+def _string_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _item_key(*, bucket: str, ordinal: int, category: str, criterion_text: str, reason_code: str) -> str:
+    digest_source = "\0".join([category, criterion_text, reason_code])
+    digest = hashlib.sha1(digest_source.encode("utf-8")).hexdigest()[:12]
+    return f"{bucket}:{ordinal}:{digest}"
+
+
+def build_match_review_item_snapshots(
+    gap_report_payload: dict[str, Any] | None,
+) -> list[MatchReviewItemSnapshot]:
+    if not isinstance(gap_report_payload, dict):
+        return []
+
+    snapshots: list[MatchReviewItemSnapshot] = []
+    for bucket in FOLLOW_UP_BUCKETS:
+        bucket_items = gap_report_payload.get(bucket, [])
+        if not isinstance(bucket_items, list):
+            continue
+        for ordinal, entry in enumerate(bucket_items):
+            if not isinstance(entry, dict):
+                continue
+            category = _string_value(entry.get("category")) or "logic_group"
+            criterion_text = _string_value(entry.get("criterion_text")) or ""
+            reason_code = (
+                _string_value(entry.get("state_reason"))
+                or _string_value(entry.get("kind"))
+                or bucket
+            )
+            state = _string_value(entry.get("state")) or "review_required"
+            evidence_payload = entry.get("evidence_payload")
+            if not isinstance(evidence_payload, dict):
+                evidence_payload = None
+            snapshots.append(
+                MatchReviewItemSnapshot(
+                    item_key=_item_key(
+                        bucket=bucket,
+                        ordinal=ordinal,
+                        category=category,
+                        criterion_text=criterion_text,
+                        reason_code=reason_code,
+                    ),
+                    bucket=bucket,
+                    reason_code=reason_code,
+                    category=category,
+                    criterion_text=criterion_text,
+                    outcome=_string_value(entry.get("outcome")),
+                    state=state,
+                    state_reason=_string_value(entry.get("state_reason")),
+                    source_snippet=_string_value(entry.get("source_snippet")),
+                    evidence_payload=evidence_payload,
+                    summary=_string_value(entry.get("summary")),
+                )
+            )
+    return snapshots

--- a/app/matching/service.py
+++ b/app/matching/service.py
@@ -7,10 +7,12 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.api.state import criterion_state_from_extracted, match_state_from_evaluations
 from app.matching.gap_report import build_gap_report_payload
+from app.matching.review_items import build_match_review_item_snapshots
 from app.models.database import (
     ExtractedCriterion,
     MatchResult,
     MatchResultCriterion,
+    MatchReviewItem,
     MatchRun,
     Patient,
     PatientBiomarker,
@@ -117,6 +119,7 @@ class PatientMatchService:
                 evaluations=effective_evaluations,
             )
             state, state_reason = match_state_from_evaluations(effective_evaluations)
+            gap_report_payload = build_gap_report_payload(effective_evaluations)
 
             result = MatchResult(
                 match_run_id=match_run.id,
@@ -131,11 +134,33 @@ class PatientMatchService:
                 unknown_count=unknown_count,
                 requires_review_count=requires_review_count,
                 summary_explanation=summary_explanation,
-                gap_report_payload=build_gap_report_payload(effective_evaluations),
+                gap_report_payload=gap_report_payload,
                 created_at=utc_now(),
             )
             self._db.add(result)
             self._db.flush()
+
+            for snapshot in build_match_review_item_snapshots(gap_report_payload):
+                self._db.add(
+                    MatchReviewItem(
+                        match_result_id=result.id,
+                        match_run_id=match_run.id,
+                        patient_id=patient.id,
+                        trial_id=trial.id,
+                        item_key=snapshot.item_key,
+                        bucket=snapshot.bucket,
+                        reason_code=snapshot.reason_code,
+                        category=snapshot.category,
+                        criterion_text=snapshot.criterion_text,
+                        outcome=snapshot.outcome,
+                        state=snapshot.state,
+                        state_reason=snapshot.state_reason,
+                        source_snippet=snapshot.source_snippet,
+                        evidence_payload=snapshot.evidence_payload,
+                        summary=snapshot.summary,
+                        created_at=result.created_at,
+                    )
+                )
 
             for evaluation in evaluations:
                 evidence_payload = evaluation.evidence_payload

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -341,9 +341,47 @@ class MatchResult(Base):
     patient = relationship("Patient", back_populates="match_results")
     trial = relationship("Trial", back_populates="match_results")
     criteria = relationship("MatchResultCriterion", back_populates="match_result", cascade="all, delete-orphan")
+    review_items = relationship("MatchReviewItem", back_populates="match_result", cascade="all, delete-orphan")
 
     __table_args__ = (
         UniqueConstraint("match_run_id", "trial_id", name="uq_match_run_trial"),
+    )
+
+
+class MatchReviewItem(Base):
+    __tablename__ = "match_review_items"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    match_result_id = Column(
+        UUID(as_uuid=True), ForeignKey("match_results.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    match_run_id = Column(
+        UUID(as_uuid=True), ForeignKey("match_runs.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    patient_id = Column(
+        UUID(as_uuid=True), ForeignKey("patients.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    trial_id = Column(
+        UUID(as_uuid=True), ForeignKey("trials.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    item_key = Column(String, nullable=False)
+    bucket = Column(String, nullable=False, index=True)
+    reason_code = Column(String, nullable=False, index=True)
+    category = Column(String, nullable=False)
+    criterion_text = Column(Text, nullable=False)
+    outcome = Column(String)
+    state = Column(String, nullable=False)
+    state_reason = Column(String)
+    source_snippet = Column(Text)
+    evidence_payload = Column(JSONB)
+    summary = Column(Text)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=utc_now)
+
+    match_result = relationship("MatchResult", back_populates="review_items")
+
+    __table_args__ = (
+        UniqueConstraint("match_result_id", "item_key", name="uq_match_review_item_result_key"),
+        Index("ix_match_review_items_queue", "bucket", "reason_code", "created_at"),
     )
 
 

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -7,9 +7,17 @@ import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
+const MATCH_BUCKET_LABELS = {
+  review_required: "Needs match review",
+  missing_data: "Needs patient data",
+  clarifiable_blockers: "Clarifiable blocker",
+  unsupported: "System limitation"
+} as const;
+
 type SearchParams = {
   reason?: string;
   page?: string;
+  match_page?: string;
 };
 
 export default async function ReviewPage({
@@ -23,13 +31,21 @@ export default async function ReviewPage({
   if (params.page) query.set("page", params.page);
   query.set("per_page", "20");
   const queue = await ctmApi.getReviewQueue(`?${query.toString()}`);
+  const showMatchPanel = !params.reason;
+  const matchQuery = new URLSearchParams();
+  if (params.match_page) matchQuery.set("page", params.match_page);
+  matchQuery.set("per_page", "20");
+  const matchQueue = showMatchPanel ? await ctmApi.getMatchReviewQueue(`?${matchQuery.toString()}`) : null;
+  const matchPage = Number(params.match_page ?? "1");
+  const hasPreviousMatchPage = matchPage > 1;
+  const hasNextMatchPage = matchQueue ? matchPage * matchQueue.per_page < matchQueue.total : false;
 
   return (
     <>
       <PageHeader
         label="Review Queue"
-        title="Resolve machine uncertainty without leaving the console."
-        description="Each row is the latest pending criterion from the latest completed run. Accept, reject, or correct against the canonical row."
+        title="Resolve extraction uncertainty and inspect downstream match ambiguity."
+        description="The primary queue remains actionable extracted criteria from the latest completed run. A separate panel surfaces latest match-side unresolved criteria so operators can inspect affected patient-trial results without conflating them with the canonical adjudication workflow."
       />
 
       <Panel title="Breakdown" eyebrow="Reasons">
@@ -104,6 +120,89 @@ export default async function ReviewPage({
             </p>
           </Panel>
         )}
+
+        <Panel
+          title="Affected match-side follow-up items"
+          eyebrow={showMatchPanel && matchQueue ? `Read-only downstream context · ${matchQueue.total} total items` : "Read-only downstream context"}
+          right={
+            showMatchPanel && matchQueue && matchQueue.total > matchQueue.per_page ? (
+              <div className="flex items-center gap-3 text-sm">
+                {hasPreviousMatchPage ? (
+                  <Link
+                    className="font-semibold text-ink underline decoration-ink/20 underline-offset-4"
+                    href={`/review?${new URLSearchParams({
+                      ...(params.page ? { page: params.page } : {}),
+                      match_page: String(matchPage - 1)
+                    }).toString()}`}
+                  >
+                    Previous match page
+                  </Link>
+                ) : null}
+                {hasNextMatchPage ? (
+                  <Link
+                    className="font-semibold text-ink underline decoration-ink/20 underline-offset-4"
+                    href={`/review?${new URLSearchParams({
+                      ...(params.page ? { page: params.page } : {}),
+                      match_page: String(matchPage + 1)
+                    }).toString()}`}
+                  >
+                    Next match page
+                  </Link>
+                ) : null}
+              </div>
+            ) : null
+          }
+        >
+          {!showMatchPanel ? (
+            <p className="text-sm leading-7 text-ink/68">
+              Match-side follow-up context is hidden while an extraction review-reason filter is active because the match queue uses a different reason vocabulary.
+              Clear the extraction reason filter to inspect downstream match follow-up items.
+            </p>
+          ) : matchQueue && matchQueue.items.length ? (
+            <div className="grid gap-4">
+              {matchQueue.items.map((item) => (
+                <article key={item.id} className="rounded-[28px] border border-ink/10 bg-white/75 p-5 shadow-card">
+                  <div className="mb-3 flex flex-wrap items-center gap-3">
+                    <StatusPill value={item.state} />
+                    <span className="text-xs uppercase tracking-[0.22em] text-ink/45">{MATCH_BUCKET_LABELS[item.bucket]}</span>
+                    <span className="text-xs uppercase tracking-[0.22em] text-ink/45">{item.category}</span>
+                    {(item.reason_codes.length ? item.reason_codes : item.reason_code ? [item.reason_code] : ["pending"]).map((reason) => (
+                      <span key={`${item.id}-${reason}`} className="text-xs uppercase tracking-[0.22em] text-ink/45">
+                        {reason}
+                      </span>
+                    ))}
+                  </div>
+                  <p className="text-base font-semibold text-ink">{item.original_text}</p>
+                  <div className="mt-3 grid gap-2 text-sm text-ink/70 lg:grid-cols-2">
+                    <p>
+                      <span className="font-semibold text-ink">Trial:</span> {item.trial_nct_id} · {item.trial_brief_title}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-ink">Patient:</span> {item.patient_id}
+                    </p>
+                    {item.source_snippet ? (
+                      <p className="lg:col-span-2">
+                        <span className="font-semibold text-ink">Source snippet:</span> {item.source_snippet}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-3">
+                    <Link
+                      className="inline-flex font-semibold text-ink underline decoration-ink/20 underline-offset-4"
+                      href={`/matches/${item.match_result_id}`}
+                    >
+                      Open match detail
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm leading-7 text-ink/68">
+              No latest match results currently expose unresolved match-side criteria.
+            </p>
+          )}
+        </Panel>
       </div>
     </>
   );

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -9,6 +9,7 @@ import type {
   IngestResponse,
   MatchResultDetail,
   MatchResultListResponse,
+  MatchReviewQueueResponse,
   MatchRunResponse,
   PatientCreatePayload,
   PatientDetail,
@@ -82,6 +83,7 @@ export const ctmApi = {
       accept: "application/fhir+json"
     }),
   getReviewQueue: (query = "") => apiRequest<ReviewQueueResponse>(`/review${query}`, { auth: true }),
+  getMatchReviewQueue: (query = "") => apiRequest<MatchReviewQueueResponse>(`/review/matches${query}`, { auth: true }),
   getPipelineStatus: () => apiRequest<PipelineStatusResponse>("/pipeline/status", { auth: true }),
   getPipelineCoverage: () => apiRequest<PipelineCoverageResponse>("/pipeline/coverage", { auth: true }),
   listPipelineRuns: (query = "") =>

--- a/frontend/src/lib/api/openapi.json
+++ b/frontend/src/lib/api/openapi.json
@@ -2145,6 +2145,240 @@
         "title": "MatchResultSummary",
         "type": "object"
       },
+      "MatchReviewQueueItemResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "bucket": {
+            "enum": [
+              "review_required",
+              "missing_data",
+              "clarifiable_blockers",
+              "unsupported"
+            ],
+            "title": "Bucket",
+            "type": "string"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "evidence_payload": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence Payload"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "const": "match_review_item",
+            "default": "match_review_item",
+            "title": "Kind",
+            "type": "string"
+          },
+          "match_result_id": {
+            "format": "uuid",
+            "title": "Match Result Id",
+            "type": "string"
+          },
+          "match_run_id": {
+            "format": "uuid",
+            "title": "Match Run Id",
+            "type": "string"
+          },
+          "original_text": {
+            "title": "Original Text",
+            "type": "string"
+          },
+          "outcome": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outcome"
+          },
+          "patient_id": {
+            "format": "uuid",
+            "title": "Patient Id",
+            "type": "string"
+          },
+          "reason_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason Code"
+          },
+          "reason_codes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Reason Codes",
+            "type": "array"
+          },
+          "review_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Reason"
+          },
+          "review_required": {
+            "title": "Review Required",
+            "type": "boolean"
+          },
+          "review_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Status"
+          },
+          "source_snippet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Snippet"
+          },
+          "state": {
+            "enum": [
+              "structured_safe",
+              "structured_low_confidence",
+              "review_required",
+              "blocked_unsupported"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "state_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Reason"
+          },
+          "trial_brief_title": {
+            "title": "Trial Brief Title",
+            "type": "string"
+          },
+          "trial_id": {
+            "format": "uuid",
+            "title": "Trial Id",
+            "type": "string"
+          },
+          "trial_nct_id": {
+            "title": "Trial Nct Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "trial_id",
+          "trial_nct_id",
+          "trial_brief_title",
+          "patient_id",
+          "match_run_id",
+          "match_result_id",
+          "bucket",
+          "category",
+          "original_text",
+          "state",
+          "review_required"
+        ],
+        "title": "MatchReviewQueueItemResponse",
+        "type": "object"
+      },
+      "MatchReviewQueueResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "breakdown_by_reason": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Breakdown By Reason",
+            "type": "object"
+          },
+          "breakdown_scope": {
+            "const": "filtered",
+            "default": "filtered",
+            "title": "Breakdown Scope",
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MatchReviewQueueItemResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "per_page": {
+            "title": "Per Page",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "per_page",
+          "breakdown_by_reason"
+        ],
+        "title": "MatchReviewQueueResponse",
+        "type": "object"
+      },
       "MatchRunResponse": {
         "additionalProperties": false,
         "properties": {
@@ -5987,6 +6221,144 @@
           }
         ],
         "summary": "Get Review Queue"
+      }
+    },
+    "/api/v1/review/matches": {
+      "get": {
+        "operationId": "get_match_review_queue_api_v1_review_matches_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Per Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reason",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reason"
+            }
+          },
+          {
+            "in": "query",
+            "name": "trial_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Trial Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "patient_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Patient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchReviewQueueResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "invalid_api_key",
+                  "detail": "Valid X-API-Key header required",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API key"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "internal_server_error",
+                  "detail": "Internal server error",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unhandled server error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Get Match Review Queue"
       }
     },
     "/api/v1/trials": {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -145,12 +145,46 @@ export type CriteriaListResponse = {
   per_page: number;
 };
 
+export type MatchReviewQueueItem = {
+  id: string;
+  kind: "match_review_item";
+  reason_code?: string | null;
+  reason_codes: string[];
+  trial_id: string;
+  trial_nct_id: string;
+  trial_brief_title: string;
+  patient_id: string;
+  match_run_id: string;
+  match_result_id: string;
+  bucket: "review_required" | "missing_data" | "clarifiable_blockers" | "unsupported";
+  category: string;
+  original_text: string;
+  outcome?: string | null;
+  state: MatchConfidenceState;
+  state_reason?: string | null;
+  review_required: boolean;
+  review_reason?: string | null;
+  review_status?: string | null;
+  source_snippet?: string | null;
+  evidence_payload?: Record<string, unknown> | null;
+  created_at?: string | null;
+};
+
 export type ReviewQueueResponse = {
   items: CriterionResponse[];
   total: number;
   page: number;
   per_page: number;
   breakdown_by_reason: Record<string, number>;
+};
+
+export type MatchReviewQueueResponse = {
+  items: MatchReviewQueueItem[];
+  total: number;
+  page: number;
+  per_page: number;
+  breakdown_by_reason: Record<string, number>;
+  breakdown_scope: "filtered";
 };
 
 export type PipelineStatusResponse = {

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -11,9 +11,23 @@ from fastapi.testclient import TestClient
 
 from app.config import settings
 from app.db.session import get_db
-from app.ingestion.service import ExternalServiceValidationError, SearchIngestBatchResult, SearchIngestTrialResult
+from app.ingestion.service import (
+    ExternalServiceValidationError,
+    SearchIngestBatchResult,
+    SearchIngestTrialResult,
+)
 from app.main import app
-from app.models.database import ExtractedCriterion, MatchResult, MatchRun, Patient, PipelineRun, Trial
+from app.matching.review_items import build_match_review_item_snapshots
+from app.models.database import (
+    ExtractedCriterion,
+    MatchResult,
+    MatchResultCriterion,
+    MatchReviewItem,
+    MatchRun,
+    Patient,
+    PipelineRun,
+    Trial,
+)
 from app.scripts.seed import sync_coding_lookups
 
 MOCK_DIR = Path(__file__).parent.parent / "fixtures" / "mock_ctgov_responses"
@@ -379,6 +393,111 @@ def _seed_match_results_for_coverage(db_session, primary_trial):
         "patient": patient,
         "secondary_trial": secondary_trial,
         "tertiary_trial": tertiary_trial,
+    }
+
+
+def _seed_match_review_queue_item(db_session):
+    trial, run, _, review_criterion = _seed_trial(db_session)
+
+    patient = Patient(external_id=f"review-queue-patient-{uuid.uuid4().hex[:8]}")
+    db_session.add(patient)
+    db_session.flush()
+
+    match_run = MatchRun(
+        patient_id=patient.id,
+        status="completed",
+        total_trials_evaluated=1,
+        eligible_trials=0,
+        possible_trials=1,
+        ineligible_trials=0,
+    )
+    db_session.add(match_run)
+    db_session.flush()
+
+    match_result = MatchResult(
+        match_run_id=match_run.id,
+        patient_id=patient.id,
+        trial_id=trial.id,
+        overall_status="possible",
+        score=0.41,
+        favorable_count=0,
+        unfavorable_count=0,
+        unknown_count=1,
+        requires_review_count=1,
+        summary_explanation="Needs human review",
+        gap_report_payload={
+            "hard_blockers": [],
+            "clarifiable_blockers": [],
+            "missing_data": [],
+            "review_required": [
+                {
+                    "kind": "review_required",
+                    "label": "Metastases",
+                    "category": review_criterion.category,
+                    "criterion_text": review_criterion.original_text,
+                    "outcome": "unknown",
+                    "state": "review_required",
+                    "state_reason": "review_required:manual_review_needed",
+                    "summary": "Criterion outcome remains unresolved and needs adjudication.",
+                    "source_snippet": "No active brain metastases",
+                    "evidence_payload": {"source_snippet": "No active brain metastases"},
+                }
+            ],
+            "unsupported": [],
+        },
+        state="review_required",
+        state_reason="review_required:manual_review_needed",
+    )
+    db_session.add(match_result)
+    db_session.flush()
+
+    review_item = None
+    for snapshot in build_match_review_item_snapshots(match_result.gap_report_payload):
+        review_item = MatchReviewItem(
+            match_result_id=match_result.id,
+            match_run_id=match_run.id,
+            patient_id=patient.id,
+            trial_id=trial.id,
+            item_key=snapshot.item_key,
+            bucket=snapshot.bucket,
+            reason_code=snapshot.reason_code,
+            category=snapshot.category,
+            criterion_text=snapshot.criterion_text,
+            outcome=snapshot.outcome,
+            state=snapshot.state,
+            state_reason=snapshot.state_reason,
+            source_snippet=snapshot.source_snippet,
+            evidence_payload=snapshot.evidence_payload,
+            summary=snapshot.summary,
+            created_at=match_result.created_at,
+        )
+        db_session.add(review_item)
+
+    match_result_criterion = MatchResultCriterion(
+        match_result_id=match_result.id,
+        criterion_id=review_criterion.id,
+        pipeline_run_id=run.id,
+        source_type="criterion",
+        source_label="Trial criterion",
+        criterion_type=review_criterion.type,
+        category=review_criterion.category,
+        criterion_text=review_criterion.original_text,
+        outcome="unknown",
+        state="review_required",
+        state_reason="review_required:manual_review_needed",
+        explanation_text="Criterion outcome remains unresolved and needs adjudication.",
+        explanation_type="review_required",
+        evidence_payload={"source_snippet": "No active brain metastases", "review_hint": "manual_review_needed"},
+    )
+    db_session.add(match_result_criterion)
+    db_session.commit()
+    return {
+        "trial": trial,
+        "patient": patient,
+        "match_run": match_run,
+        "match_result": match_result,
+        "match_result_criterion": match_result_criterion,
+        "review_item": review_item,
     }
 
 
@@ -995,6 +1114,70 @@ class TestReviewQueue:
         data = response.json()
         assert "fuzzy_match" in data["breakdown_by_reason"]
         assert data["breakdown_by_reason"]["fuzzy_match"] >= 1
+
+    def test_review_queue_includes_match_result_criteria_requiring_review(self, client, db_session):
+        seeded = _seed_match_review_queue_item(db_session)
+
+        response = client.get("/api/v1/review/matches")
+
+        assert response.status_code == 200
+        data = response.json()
+        match_items = [item for item in data["items"] if item.get("kind") == "match_review_item"]
+        assert match_items, data
+        match_item = next(item for item in match_items if item["match_result_id"] == str(seeded["match_result"].id))
+        assert match_item["patient_id"] == str(seeded["patient"].id)
+        assert match_item["match_run_id"] == str(seeded["match_run"].id)
+        assert match_item["match_result_id"] == str(seeded["match_result"].id)
+        assert match_item["trial_id"] == str(seeded["trial"].id)
+        assert match_item["bucket"] == "review_required"
+        assert match_item["review_required"] is True
+        assert match_item["state"] == "review_required"
+        assert match_item["reason_code"] == "review_required:manual_review_needed"
+
+    def test_match_review_queue_filters_by_reason_and_patient(self, client, db_session):
+        seeded = _seed_match_review_queue_item(db_session)
+
+        response = client.get(
+            "/api/v1/review/matches"
+            f"?reason=review_required:manual_review_needed&patient_id={seeded['patient'].id}"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] >= 1
+        assert data["breakdown_by_reason"] == {"review_required:manual_review_needed": data["total"]}
+        for item in data["items"]:
+            assert item["patient_id"] == str(seeded["patient"].id)
+            assert item["reason_code"] == "review_required:manual_review_needed"
+
+    def test_match_review_queue_marks_unsupported_items_as_follow_up_not_pending_review(self, client, db_session):
+        seeded = _seed_match_review_queue_item(db_session)
+        unsupported = MatchReviewItem(
+            match_result_id=seeded["match_result"].id,
+            match_run_id=seeded["match_run"].id,
+            patient_id=seeded["patient"].id,
+            trial_id=seeded["trial"].id,
+            item_key="unsupported:0:test",
+            bucket="unsupported",
+            reason_code="blocked_unsupported",
+            category="concomitant_medication",
+            criterion_text="No strong CYP3A inhibitors",
+            outcome="unknown",
+            state="blocked_unsupported",
+            state_reason="blocked_unsupported",
+            summary="Medication logic is unsupported.",
+        )
+        db_session.add(unsupported)
+        db_session.commit()
+
+        response = client.get("/api/v1/review/matches?reason=blocked_unsupported")
+
+        assert response.status_code == 200
+        data = response.json()
+        item = next(item for item in data["items"] if item["id"] == str(unsupported.id))
+        assert item["bucket"] == "unsupported"
+        assert item["review_required"] is False
+        assert item["review_status"] is None
 
     def test_review_queue_ignores_pending_items_from_superseded_runs(self, client, db_session):
         trial, _, _, _ = _seed_trial(db_session)

--- a/tests/unit/test_match_review_items.py
+++ b/tests/unit/test_match_review_items.py
@@ -1,0 +1,65 @@
+from app.matching.review_items import build_match_review_item_snapshots
+
+
+def test_build_match_review_item_snapshots_persists_follow_up_buckets_only():
+    payload = {
+        "review_required": [
+            {
+                "category": "biomarker",
+                "criterion_text": "EGFR status unclear",
+                "outcome": "unknown",
+                "state": "review_required",
+                "state_reason": "review_required:manual_review_needed",
+                "summary": "Needs adjudication.",
+                "source_snippet": "EGFR equivocal",
+                "evidence_payload": {"source_snippet": "EGFR equivocal"},
+            }
+        ],
+        "missing_data": [
+            {
+                "kind": "missing_data",
+                "category": "lab_value",
+                "criterion_text": "ANC >= 1500/uL",
+                "outcome": "unknown",
+                "state": "structured_low_confidence",
+            }
+        ],
+        "hard_blockers": [
+            {
+                "category": "age",
+                "criterion_text": "Age < 18",
+                "outcome": "not_matched",
+                "state": "structured_safe",
+            }
+        ],
+    }
+
+    items = build_match_review_item_snapshots(payload)
+
+    assert [item.bucket for item in items] == ["review_required", "missing_data"]
+    assert items[0].reason_code == "review_required:manual_review_needed"
+    assert items[0].item_key.startswith("review_required:0:")
+    assert items[0].source_snippet == "EGFR equivocal"
+    assert items[0].evidence_payload == {"source_snippet": "EGFR equivocal"}
+    assert items[1].reason_code == "missing_data"
+    assert items[1].item_key.startswith("missing_data:0:")
+
+
+def test_build_match_review_item_snapshots_ignores_malformed_bucket_values():
+    payload = {
+        "review_required": {"not": "a list"},
+        "unsupported": [
+            {
+                "category": "concomitant_medication",
+                "criterion_text": "No strong CYP3A inhibitors",
+                "state": "blocked_unsupported",
+            }
+        ],
+    }
+
+    items = build_match_review_item_snapshots(payload)
+
+    assert len(items) == 1
+    assert items[0].bucket == "unsupported"
+    assert items[0].reason_code == "unsupported"
+    assert items[0].state == "blocked_unsupported"


### PR DESCRIPTION
## Summary

- Adds the human review queue foundation for issue #11 without cutting a patch tag: this is a new workflow feature/architectural reconstruction, not a user-facing hotfix that needs an independent `v0.2.x` release.
- Reconstructs the review architecture into two lanes:
  - `/review` remains the canonical extraction adjudication queue for `ExtractedCriterion` review work.
  - `/review/matches` exposes downstream match follow-up items derived from persisted match-time snapshots.
- Persists `match_review_items` from gap-report follow-up buckets (`review_required`, `missing_data`, `clarifiable_blockers`, `unsupported`) so reviewer-facing ambiguity does not get recomputed from live state and drift away from historical match semantics.
- Adds migration/backfill support, API response schemas, OpenAPI/client type updates, and review-page UI wiring for the match-side lane.

## Commit summary

- `feat: add human review queue for match follow-ups`
  - Closes #11.
  - Mentions the architectural reconstruction explicitly: extraction adjudication and match follow-up are separated instead of overloading the existing review queue contract.
  - Calls out the addressed issues: queue-friendly API shape, machine-readable reason codes, persisted context for ambiguous match items, and future adjudication support without a schema rewrite.

## Architectural reconstruction

This PR avoids changing the existing `/review` contract away from extraction criteria. Instead, it introduces a separate match-side queue surface backed by persisted `match_review_items`. That keeps human-in-the-loop extraction review distinct from downstream match ambiguity/follow-up, while still presenting both on the review page.

The match-side queue is snapshot-first: new match results persist follow-up items from the generated `gap_report_payload`, and the migration provides conservative historical backfill behavior for existing rows.

## Verification

- [x] Changed-file Ruff
- [x] Targeted backend tests: `67 passed`
- [x] Full backend suite: `399 passed`
- [x] Frontend typecheck
- [x] Frontend build
- [x] Local Codex review gate: pass, no material findings

Closes #11.
