### PR TITLE
feat: add what-if match simulator

### DIFF
--- a/app/api/routes/patients.py
+++ b/app/api/routes/patients.py
@@ -16,6 +16,8 @@ from app.api.schemas import (
     MatchResultListResponse,
     MatchResultSummary,
     MatchRunResponse,
+    MatchSimulationRequest,
+    MatchSimulationResponse,
     PatientBiomarkerInput,
     PatientBiomarkerResponse,
     PatientConditionInput,
@@ -36,6 +38,13 @@ from app.api.state import criterion_state_from_match_result_criterion, match_sta
 from app.db.session import get_db
 from app.matching.gap_report import build_gap_report_payload, legacy_gap_report_payload
 from app.matching.service import CriterionEvaluation, PatientMatchService, _collapse_or_group
+from app.matching.simulation import (
+    applied_changes_from_request,
+    build_result_deltas,
+    build_simulated_patient,
+    summarize_simulation_results,
+    summarize_source_results,
+)
 from app.models.database import (
     MatchResult,
     MatchRun,
@@ -167,6 +176,42 @@ def match_patient(
     return _match_run_detail(match_run)
 
 
+@router.post(
+    "/patients/{patient_id}/simulate-match",
+    response_model=MatchSimulationResponse,
+    responses=PROTECTED_RESOURCE_RESPONSES,
+)
+def simulate_patient_match(
+    patient_id: UUID,
+    payload: MatchSimulationRequest,
+    _: str = Depends(require_api_key),
+    service: PatientMatchService = Depends(_get_match_service),
+    db: Session = Depends(get_db),
+):
+    patient = service.get_patient(patient_id)
+    if not patient:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
+    # Recompute the baseline against the same current trial/criterion corpus used for
+    # the scenario. Comparing against an older persisted match run would mix patient
+    # edits with unrelated trial/pipeline drift and produce misleading deltas.
+    baseline_source = "computed"
+    baseline_results = service.evaluate_patient_matches(patient)
+
+    simulated_patient = build_simulated_patient(patient, payload)
+    scenario_results = service.evaluate_patient_matches(simulated_patient)
+
+    return MatchSimulationResponse(
+        patient_id=patient.id,
+        baseline_source=baseline_source,
+        applied_changes=applied_changes_from_request(payload),
+        baseline_summary=summarize_source_results(baseline_results, baseline_source),
+        scenario_summary=summarize_source_results(scenario_results, "simulated"),
+        deltas=summarize_simulation_results(baseline_results, scenario_results),
+        results=build_result_deltas(baseline_results, scenario_results),
+    )
+
+
 @router.get(
     "/patients/{patient_id}/matches",
     response_model=MatchResultListResponse,
@@ -233,6 +278,16 @@ def _load_match_run_or_404(match_run_id: UUID, db: Session) -> MatchRun:
     if not match_run:
         raise HTTPException(status_code=404, detail="Match run not found")
     return match_run
+
+
+def _latest_completed_match_run(patient_id: UUID, db: Session) -> MatchRun | None:
+    return (
+        db.query(MatchRun)
+        .options(selectinload(MatchRun.results).selectinload(MatchResult.trial))
+        .filter(MatchRun.patient_id == patient_id, MatchRun.status == "completed")
+        .order_by(MatchRun.completed_at.desc().nullslast(), MatchRun.created_at.desc(), MatchRun.id.desc())
+        .first()
+    )
 
 
 def _replace_patient_facts(patient: Patient, payload: PatientCreateRequest | PatientUpdateRequest) -> None:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,8 +1,9 @@
 from datetime import date, datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 
 class APIModel(BaseModel):
@@ -693,6 +694,78 @@ class MatchResultListResponse(APIModel):
     total: int
     page: int
     per_page: int
+
+
+class MatchSimulationRequest(APIModel):
+    ecog_status: Annotated[int, Field(ge=0, le=5)] | SkipJsonSchema[None] = None
+    biomarkers: list[PatientBiomarkerInput] | SkipJsonSchema[None] = None
+    therapies: list[PatientTherapyInput] | SkipJsonSchema[None] = None
+    medications: list[PatientMedicationInput] | SkipJsonSchema[None] = None
+    labs: list[PatientLabInput] | SkipJsonSchema[None] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_no_explicit_null_fields(cls, data):
+        if isinstance(data, dict):
+            null_fields = [field for field, value in data.items() if value is None]
+            if null_fields:
+                raise ValueError(
+                    "Omit fields to preserve baseline values; use empty lists to clear simulated fact lists."
+                )
+        return data
+
+
+class MatchSimulationAppliedChanges(APIModel):
+    ecog_status: int | None = None
+    biomarkers: list[PatientBiomarkerInput] | None = None
+    therapies: list[PatientTherapyInput] | None = None
+    medications: list[PatientMedicationInput] | None = None
+    labs: list[PatientLabInput] | None = None
+
+
+class MatchSimulationSummary(APIModel):
+    total_trials: int
+    eligible: int
+    possible: int
+    ineligible: int
+    newly_eligible: int = 0
+    newly_blocked: int = 0
+    status_changed: int = 0
+    unchanged: int = 0
+    review_required: int = 0
+    source: Literal["persisted", "computed", "simulated"]
+
+
+class MatchSimulationResultDelta(APIModel):
+    trial_id: UUID
+    trial_nct_id: str
+    trial_brief_title: str
+    baseline_status: Literal["eligible", "possible", "ineligible"] | None = None
+    scenario_status: Literal["eligible", "possible", "ineligible"] | None = None
+    status_changed: bool
+    blockers_removed: list[str] = Field(default_factory=list)
+    blockers_added: list[str] = Field(default_factory=list)
+    missing_data_removed: list[str] = Field(default_factory=list)
+    missing_data_added: list[str] = Field(default_factory=list)
+    clarifiable_blockers_removed: list[str] = Field(default_factory=list)
+    clarifiable_blockers_added: list[str] = Field(default_factory=list)
+    unsupported_removed: list[str] = Field(default_factory=list)
+    unsupported_added: list[str] = Field(default_factory=list)
+    review_required_removed: list[str] = Field(default_factory=list)
+    review_required_added: list[str] = Field(default_factory=list)
+    baseline_summary_explanation: str | None = None
+    scenario_summary_explanation: str | None = None
+
+
+class MatchSimulationResponse(APIModel):
+    patient_id: UUID
+    scenario_source: Literal["simulated"] = "simulated"
+    baseline_source: Literal["persisted", "computed"]
+    applied_changes: MatchSimulationAppliedChanges
+    baseline_summary: MatchSimulationSummary
+    scenario_summary: MatchSimulationSummary
+    deltas: MatchSimulationSummary
+    results: list[MatchSimulationResultDelta] = Field(default_factory=list)
 
 
 class ErrorResponse(APIModel):

--- a/app/matching/service.py
+++ b/app/matching/service.py
@@ -60,6 +60,24 @@ class CriterionEvaluation:
     evidence_payload: dict[str, Any] | None = None
 
 
+@dataclass
+class EvaluatedTrialMatch:
+    trial: Trial
+    trial_id: object
+    overall_status: str
+    state: str
+    state_reason: str | None
+    score: float
+    favorable_count: int
+    unfavorable_count: int
+    unknown_count: int
+    requires_review_count: int
+    summary_explanation: str
+    gap_report_payload: dict[str, Any]
+    evaluations: list[CriterionEvaluation]
+    effective_evaluations: list[CriterionEvaluation]
+
+
 class PatientMatchService:
     def __init__(self, db: Session):
         self._db = db
@@ -73,19 +91,14 @@ class PatientMatchService:
             selectinload(Patient.medications),
         ).filter(Patient.id == patient_id).first()
 
-    def run_match(self, patient: Patient) -> MatchRun:
+    def evaluate_patient_matches(self, patient: Patient) -> list[EvaluatedTrialMatch]:
         trials = (
             self._db.query(Trial)
             .options(selectinload(Trial.criteria), selectinload(Trial.pipeline_runs))
             .order_by(Trial.nct_id.asc())
             .all()
         )
-
-        match_run = MatchRun(patient_id=patient.id, status="running", created_at=utc_now())
-        self._db.add(match_run)
-        self._db.flush()
-
-        summaries: list[MatchResult] = []
+        summaries: list[EvaluatedTrialMatch] = []
         for trial in trials:
             latest_run = _latest_completed_run(trial)
             evaluations = self._evaluate_trial(patient, trial, latest_run)
@@ -120,33 +133,69 @@ class PatientMatchService:
             )
             state, state_reason = match_state_from_evaluations(effective_evaluations)
             gap_report_payload = build_gap_report_payload(effective_evaluations)
+            summaries.append(
+                EvaluatedTrialMatch(
+                    trial=trial,
+                    trial_id=trial.id,
+                    overall_status=overall_status,
+                    state=state,
+                    state_reason=state_reason,
+                    score=score,
+                    favorable_count=favorable_count,
+                    unfavorable_count=unfavorable_count,
+                    unknown_count=unknown_count,
+                    requires_review_count=requires_review_count,
+                    summary_explanation=summary_explanation,
+                    gap_report_payload=gap_report_payload,
+                    evaluations=evaluations,
+                    effective_evaluations=effective_evaluations,
+                )
+            )
 
+        summaries.sort(
+            key=lambda result: (
+                _STATUS_ORDER[result.overall_status],
+                -_ranking_metrics(result)[0],
+                -_ranking_metrics(result)[1],
+                str(result.trial_id),
+            )
+        )
+        return summaries
+
+    def run_match(self, patient: Patient) -> MatchRun:
+        match_run = MatchRun(patient_id=patient.id, status="running", created_at=utc_now())
+        self._db.add(match_run)
+        self._db.flush()
+
+        evaluated_matches = self.evaluate_patient_matches(patient)
+        persisted_results: list[MatchResult] = []
+        for evaluated in evaluated_matches:
             result = MatchResult(
                 match_run_id=match_run.id,
                 patient_id=patient.id,
-                trial_id=trial.id,
-                overall_status=overall_status,
-                state=state,
-                state_reason=state_reason,
-                score=score,
-                favorable_count=favorable_count,
-                unfavorable_count=unfavorable_count,
-                unknown_count=unknown_count,
-                requires_review_count=requires_review_count,
-                summary_explanation=summary_explanation,
-                gap_report_payload=gap_report_payload,
+                trial_id=evaluated.trial_id,
+                overall_status=evaluated.overall_status,
+                state=evaluated.state,
+                state_reason=evaluated.state_reason,
+                score=evaluated.score,
+                favorable_count=evaluated.favorable_count,
+                unfavorable_count=evaluated.unfavorable_count,
+                unknown_count=evaluated.unknown_count,
+                requires_review_count=evaluated.requires_review_count,
+                summary_explanation=evaluated.summary_explanation,
+                gap_report_payload=evaluated.gap_report_payload,
                 created_at=utc_now(),
             )
             self._db.add(result)
             self._db.flush()
 
-            for snapshot in build_match_review_item_snapshots(gap_report_payload):
+            for snapshot in build_match_review_item_snapshots(evaluated.gap_report_payload):
                 self._db.add(
                     MatchReviewItem(
                         match_result_id=result.id,
                         match_run_id=match_run.id,
                         patient_id=patient.id,
-                        trial_id=trial.id,
+                        trial_id=evaluated.trial_id,
                         item_key=snapshot.item_key,
                         bucket=snapshot.bucket,
                         reason_code=snapshot.reason_code,
@@ -162,7 +211,7 @@ class PatientMatchService:
                     )
                 )
 
-            for evaluation in evaluations:
+            for evaluation in evaluated.evaluations:
                 evidence_payload = evaluation.evidence_payload
                 if isinstance(evidence_payload, dict):
                     evidence_payload = {
@@ -192,21 +241,12 @@ class PatientMatchService:
                         evidence_payload=evidence_payload,
                     )
                 )
+            persisted_results.append(result)
 
-            summaries.append(result)
-
-        summaries.sort(
-            key=lambda result: (
-                _STATUS_ORDER[result.overall_status],
-                -_ranking_metrics(result)[0],
-                -_ranking_metrics(result)[1],
-                str(result.trial_id),
-            )
-        )
-        match_run.total_trials_evaluated = len(summaries)
-        match_run.eligible_trials = sum(1 for result in summaries if result.overall_status == "eligible")
-        match_run.possible_trials = sum(1 for result in summaries if result.overall_status == "possible")
-        match_run.ineligible_trials = sum(1 for result in summaries if result.overall_status == "ineligible")
+        match_run.total_trials_evaluated = len(persisted_results)
+        match_run.eligible_trials = sum(1 for result in persisted_results if result.overall_status == "eligible")
+        match_run.possible_trials = sum(1 for result in persisted_results if result.overall_status == "possible")
+        match_run.ineligible_trials = sum(1 for result in persisted_results if result.overall_status == "ineligible")
         match_run.status = "completed"
         match_run.completed_at = utc_now()
 

--- a/app/matching/simulation.py
+++ b/app/matching/simulation.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable
+
+from app.api.schemas import (
+    MatchSimulationAppliedChanges,
+    MatchSimulationRequest,
+    MatchSimulationResultDelta,
+    MatchSimulationSummary,
+)
+from app.models.database import Patient, PatientBiomarker, PatientLab, PatientMedication, PatientTherapy
+
+_STATUS_RANK = {"ineligible": 0, "possible": 1, "eligible": 2}
+_GAP_BUCKETS = {
+    "hard_blockers": "blockers",
+    "missing_data": "missing_data",
+    "clarifiable_blockers": "clarifiable_blockers",
+    "unsupported": "unsupported",
+    "review_required": "review_required",
+}
+
+
+def build_simulated_patient(patient: Patient, patch: MatchSimulationRequest) -> Patient:
+    simulated = Patient(
+        id=patient.id,
+        external_id=patient.external_id,
+        sex=patient.sex,
+        birth_date=patient.birth_date,
+        ecog_status=patient.ecog_status if patch.ecog_status is None else patch.ecog_status,
+        is_healthy_volunteer=patient.is_healthy_volunteer,
+        can_consent=patient.can_consent,
+        protocol_compliant=patient.protocol_compliant,
+        claustrophobic=patient.claustrophobic,
+        motion_intolerant=patient.motion_intolerant,
+        pregnant=patient.pregnant,
+        mr_device_present=patient.mr_device_present,
+        country=patient.country,
+        state=patient.state,
+        city=patient.city,
+        latitude=patient.latitude,
+        longitude=patient.longitude,
+        created_at=patient.created_at,
+        updated_at=patient.updated_at,
+    )
+    simulated.conditions = [
+        type(condition)(description=condition.description, coded_concepts=condition.coded_concepts or [])
+        for condition in patient.conditions
+    ]
+    simulated.biomarkers = (
+        [_biomarker_from_input(item) for item in patch.biomarkers]
+        if patch.biomarkers is not None
+        else [_copy_biomarker(item) for item in patient.biomarkers]
+    )
+    simulated.labs = (
+        [_lab_from_input(item) for item in patch.labs]
+        if patch.labs is not None
+        else [_copy_lab(item) for item in patient.labs]
+    )
+    simulated.therapies = (
+        [_therapy_from_input(item) for item in patch.therapies]
+        if patch.therapies is not None
+        else [_copy_therapy(item) for item in patient.therapies]
+    )
+    simulated.medications = (
+        [_medication_from_input(item) for item in patch.medications]
+        if patch.medications is not None
+        else [_copy_medication(item) for item in patient.medications]
+    )
+    return simulated
+
+
+def applied_changes_from_request(patch: MatchSimulationRequest) -> MatchSimulationAppliedChanges:
+    data = {field: getattr(patch, field) for field in patch.model_fields_set}
+    return MatchSimulationAppliedChanges.model_validate(data)
+
+
+def summarize_source_results(results: Iterable[Any], source: str) -> MatchSimulationSummary:
+    items = list(results)
+    counts = Counter(item.overall_status for item in items)
+    return MatchSimulationSummary(
+        total_trials=len(items),
+        eligible=counts["eligible"],
+        possible=counts["possible"],
+        ineligible=counts["ineligible"],
+        review_required=sum(1 for item in items if getattr(item, "requires_review_count", 0)),
+        source=source,
+    )
+
+
+def summarize_simulation_results(
+    baseline_results: Iterable[Any], scenario_results: Iterable[Any]
+) -> MatchSimulationSummary:
+    baseline_by_trial = {_trial_key(result): result for result in baseline_results}
+    scenario_by_trial = {_trial_key(result): result for result in scenario_results}
+    all_keys = sorted(set(baseline_by_trial) | set(scenario_by_trial), key=str)
+    status_changed = 0
+    newly_eligible = 0
+    newly_blocked = 0
+    unchanged = 0
+    review_required = 0
+    scenario_status_counts: Counter[str] = Counter()
+    for key in all_keys:
+        baseline = baseline_by_trial.get(key)
+        scenario = scenario_by_trial.get(key)
+        baseline_status = getattr(baseline, "overall_status", None)
+        scenario_status = getattr(scenario, "overall_status", None)
+        if scenario_status:
+            scenario_status_counts[scenario_status] += 1
+        if scenario and getattr(scenario, "requires_review_count", 0):
+            review_required += 1
+        if baseline_status == scenario_status:
+            unchanged += 1
+        else:
+            status_changed += 1
+            if _became_more_eligible(baseline_status, scenario_status):
+                newly_eligible += 1
+            if _became_more_blocked(baseline_status, scenario_status):
+                newly_blocked += 1
+    return MatchSimulationSummary(
+        total_trials=len(all_keys),
+        eligible=scenario_status_counts["eligible"],
+        possible=scenario_status_counts["possible"],
+        ineligible=scenario_status_counts["ineligible"],
+        newly_eligible=newly_eligible,
+        newly_blocked=newly_blocked,
+        status_changed=status_changed,
+        unchanged=unchanged,
+        review_required=review_required,
+        source="simulated",
+    )
+
+
+def build_result_delta(baseline: Any | None, scenario: Any | None) -> MatchSimulationResultDelta:
+    representative = scenario or baseline
+    baseline_status = getattr(baseline, "overall_status", None)
+    scenario_status = getattr(scenario, "overall_status", None)
+    removed_added: dict[str, tuple[list[str], list[str]]] = {}
+    for bucket, label in _GAP_BUCKETS.items():
+        before = set(_gap_texts(getattr(baseline, "gap_report_payload", None), bucket)) if baseline else set()
+        after = set(_gap_texts(getattr(scenario, "gap_report_payload", None), bucket)) if scenario else set()
+        removed_added[label] = (sorted(before - after), sorted(after - before))
+    return MatchSimulationResultDelta(
+        trial_id=getattr(representative.trial, "id", representative.trial_id),
+        trial_nct_id=representative.trial.nct_id,
+        trial_brief_title=representative.trial.brief_title,
+        baseline_status=baseline_status,
+        scenario_status=scenario_status,
+        status_changed=baseline_status != scenario_status,
+        blockers_removed=removed_added["blockers"][0],
+        blockers_added=removed_added["blockers"][1],
+        missing_data_removed=removed_added["missing_data"][0],
+        missing_data_added=removed_added["missing_data"][1],
+        clarifiable_blockers_removed=removed_added["clarifiable_blockers"][0],
+        clarifiable_blockers_added=removed_added["clarifiable_blockers"][1],
+        unsupported_removed=removed_added["unsupported"][0],
+        unsupported_added=removed_added["unsupported"][1],
+        review_required_removed=removed_added["review_required"][0],
+        review_required_added=removed_added["review_required"][1],
+        baseline_summary_explanation=getattr(baseline, "summary_explanation", None),
+        scenario_summary_explanation=getattr(scenario, "summary_explanation", None),
+    )
+
+
+def build_result_deltas(
+    baseline_results: Iterable[Any], scenario_results: Iterable[Any]
+) -> list[MatchSimulationResultDelta]:
+    baseline_by_trial = {_trial_key(result): result for result in baseline_results}
+    scenario_by_trial = {_trial_key(result): result for result in scenario_results}
+    deltas = [
+        build_result_delta(baseline_by_trial.get(key), scenario_by_trial.get(key))
+        for key in set(baseline_by_trial) | set(scenario_by_trial)
+    ]
+    return sorted(
+        deltas,
+        key=lambda item: (
+            not item.status_changed,
+            -int(item.scenario_status == "eligible"),
+            item.trial_nct_id,
+        ),
+    )
+
+
+def _trial_key(result: Any) -> Any:
+    return getattr(result, "trial_id", None) or result.trial.id
+
+
+def _gap_texts(payload: Any, bucket: str) -> list[str]:
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get(bucket) or []
+    texts = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        text = entry.get("criterion_text") or entry.get("summary") or entry.get("category")
+        if isinstance(text, str) and text.strip():
+            texts.append(text.strip())
+    return texts
+
+
+def _became_more_eligible(baseline_status: str | None, scenario_status: str | None) -> bool:
+    if baseline_status is None or scenario_status is None:
+        return False
+    return _STATUS_RANK[scenario_status] > _STATUS_RANK[baseline_status]
+
+
+def _became_more_blocked(baseline_status: str | None, scenario_status: str | None) -> bool:
+    if baseline_status is None or scenario_status is None:
+        return False
+    return _STATUS_RANK[scenario_status] < _STATUS_RANK[baseline_status]
+
+
+def _copy_biomarker(item: PatientBiomarker) -> PatientBiomarker:
+    return PatientBiomarker(
+        description=item.description, coded_concepts=item.coded_concepts or [], value_text=item.value_text
+    )
+
+
+def _copy_lab(item: PatientLab) -> PatientLab:
+    return PatientLab(
+        description=item.description,
+        coded_concepts=item.coded_concepts or [],
+        value_numeric=item.value_numeric,
+        value_text=item.value_text,
+        unit=item.unit,
+    )
+
+
+def _copy_therapy(item: PatientTherapy) -> PatientTherapy:
+    return PatientTherapy(
+        description=item.description,
+        coded_concepts=item.coded_concepts or [],
+        line_of_therapy=item.line_of_therapy,
+        completed=item.completed,
+    )
+
+
+def _copy_medication(item: PatientMedication) -> PatientMedication:
+    return PatientMedication(description=item.description, coded_concepts=item.coded_concepts or [], active=item.active)
+
+
+def _biomarker_from_input(item) -> PatientBiomarker:
+    return PatientBiomarker(
+        description=item.description, coded_concepts=item.model_dump()["coded_concepts"], value_text=item.value_text
+    )
+
+
+def _lab_from_input(item) -> PatientLab:
+    return PatientLab(
+        description=item.description,
+        coded_concepts=item.model_dump()["coded_concepts"],
+        value_numeric=item.value_numeric,
+        value_text=item.value_text,
+        unit=item.unit,
+    )
+
+
+def _therapy_from_input(item) -> PatientTherapy:
+    return PatientTherapy(
+        description=item.description,
+        coded_concepts=item.model_dump()["coded_concepts"],
+        line_of_therapy=item.line_of_therapy,
+        completed=item.completed,
+    )
+
+
+def _medication_from_input(item) -> PatientMedication:
+    return PatientMedication(
+        description=item.description, coded_concepts=item.model_dump()["coded_concepts"], active=item.active
+    )

--- a/frontend/src/app/actions.ts
+++ b/frontend/src/app/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 
 import { ctmApi } from "@/lib/api/client";
+import { saveSimulationScenario } from "@/lib/simulation-store";
 
 const booleanStringSchema = z.enum(["true", "false"]);
 const numericStringSchema = z.string().trim().refine(
@@ -51,6 +52,21 @@ const searchIngestSchema = z.object({
   (value) => Boolean(value.condition || value.status || value.phase),
   { message: "Provide at least one search field." }
 );
+
+const simulateMatchSchema = z.object({
+  patient_id: z.string().uuid(),
+  ecog_status: ecogStringSchema.optional(),
+  biomarkers: z.string().trim().optional(),
+  biomarkers_replace: z.enum(["true"]).optional(),
+  medications: z.string().trim().optional(),
+  medications_replace: z.enum(["true"]).optional(),
+  therapies: z.string().trim().optional(),
+  therapies_replace: z.enum(["true"]).optional(),
+  lab_name: z.string().trim().optional(),
+  lab_value: numericStringSchema.optional(),
+  lab_unit: z.string().trim().optional(),
+  labs_replace: z.enum(["true"]).optional()
+});
 
 function splitLines(value?: string): string[] {
   if (!value) {
@@ -121,6 +137,16 @@ function redirectToPipelineWithError(error: string, values?: Record<string, stri
     }
   }
   redirect(`/pipeline?${query.toString()}`);
+}
+
+function redirectToPatientWithError(patientId: string, error: string, values?: Record<string, string | undefined>): never {
+  const query = new URLSearchParams({ error });
+  for (const [key, value] of Object.entries(values ?? {})) {
+    if (value && key !== "patient_id") {
+      query.set(key, value);
+    }
+  }
+  redirect(`/patients/${patientId}?${query.toString()}`);
 }
 
 function redirectToPatientsWithError(error: string, values?: Record<string, string | undefined>): never {
@@ -278,6 +304,53 @@ export async function matchPatientAction(formData: FormData) {
   revalidatePath("/patients");
   const topResult = run.results[0];
   redirect(topResult ? `/matches/${topResult.id}` : `/patients/${patientId}`);
+}
+
+export async function simulateMatchAction(formData: FormData) {
+  const submitted = normalizedFormEntries(formData);
+  const parsed = simulateMatchSchema.safeParse(submitted);
+  if (!parsed.success) {
+    const patientId = submitted.patient_id ?? "";
+    if (z.string().uuid().safeParse(patientId).success) {
+      redirectToPatientWithError(patientId, actionErrorMessage(parsed.error, "Simulation failed validation."), submitted);
+    }
+    redirectToPatientsWithError(actionErrorMessage(parsed.error, "Simulation failed validation."), submitted);
+  }
+
+  const data = parsed.data;
+  const payload = {
+    ...(data.ecog_status !== undefined ? { ecog_status: safeNumber(data.ecog_status) } : {}),
+    ...(data.biomarkers_replace === "true"
+      ? { biomarkers: splitLines(data.biomarkers).map((description) => ({ description })) }
+      : {}),
+    ...(data.medications_replace === "true"
+      ? { medications: splitLines(data.medications).map((description) => ({ description, active: true })) }
+      : {}),
+    ...(data.therapies_replace === "true"
+      ? { therapies: splitLines(data.therapies).map((description) => ({ description })) }
+      : {}),
+    ...(data.labs_replace === "true"
+      ? {
+          labs: data.lab_name
+            ? [
+                {
+                  description: data.lab_name,
+                  value_numeric: safeNumber(data.lab_value),
+                  unit: data.lab_unit || undefined
+                }
+              ]
+            : []
+        }
+      : {})
+  };
+  let token;
+  try {
+    token = await saveSimulationScenario(data.patient_id, payload);
+  } catch (error) {
+    redirectToPatientWithError(data.patient_id, actionErrorMessage(error, "Simulation scenario could not be saved."), submitted);
+  }
+
+  redirect(`/patients/${data.patient_id}/simulate?scenario=${token}`);
 }
 
 export async function reviewCriterionAction(formData: FormData) {

--- a/frontend/src/app/patients/[patientId]/page.tsx
+++ b/frontend/src/app/patients/[patientId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { matchPatientAction } from "@/app/actions";
+import { matchPatientAction, simulateMatchAction } from "@/app/actions";
 import { PageHeader } from "@/components/page-header";
 import { Panel } from "@/components/panel";
 import { StatusPill } from "@/components/status-pill";
@@ -9,12 +9,22 @@ import { formatDate, formatPercent } from "@/lib/format";
 
 export const dynamic = "force-dynamic";
 
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function firstValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
 export default async function PatientDetailPage({
-  params
+  params,
+  searchParams
 }: {
   params: Promise<{ patientId: string }>;
+  searchParams?: Promise<SearchParams>;
 }) {
   const { patientId } = await params;
+  const queryParams = (await searchParams) ?? {};
+  const error = firstValue(queryParams.error);
   const [patient, matches] = await Promise.all([
     ctmApi.getPatient(patientId),
     ctmApi.listPatientMatches(patientId, "?per_page=20")
@@ -37,6 +47,14 @@ export default async function PatientDetailPage({
       />
 
       <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
+        {error ? (
+          <div className="xl:col-span-2">
+            <Panel title="Simulation request failed" eyebrow="Validation error">
+              <p className="text-sm text-red-700">{error}</p>
+            </Panel>
+          </div>
+        ) : null}
+
         <Panel title="Profile" eyebrow="Normalized facts">
           <div className="space-y-4 text-sm text-ink/75">
             <p>Sex: {patient.sex ?? "Unknown"}</p>
@@ -52,6 +70,97 @@ export default async function PatientDetailPage({
             <p>Biomarkers: {patient.biomarkers.map((item) => item.description).join(", ") || "None"}</p>
             <p>Medications: {patient.medications.map((item) => item.description).join(", ") || "None"}</p>
           </div>
+        </Panel>
+
+        <Panel title="What-if simulator" eyebrow="Read-only scenario">
+          <form action={simulateMatchAction} className="grid gap-4 text-sm text-ink/75">
+            <input name="patient_id" type="hidden" value={patient.id} />
+            <p>
+              Runs a simulated match without changing this patient. Leave ECOG blank to preserve the current value;
+              fact lists are preserved unless you explicitly choose to replace or clear them.
+            </p>
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-ink/45">ECOG status</span>
+              <input
+                className="rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                inputMode="numeric"
+                max={5}
+                min={0}
+                name="ecog_status"
+                placeholder={
+                  patient.ecog_status === null || patient.ecog_status === undefined
+                    ? "Leave blank to preserve"
+                    : `Current: ${patient.ecog_status}`
+                }
+                type="number"
+              />
+              <p className="text-xs text-ink/50">Leave blank to preserve the current ECOG value.</p>
+            </label>
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-ink/45">Biomarkers</span>
+              <textarea
+                className="min-h-24 rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                name="biomarkers"
+                placeholder="Optional replacement list; leave blank to preserve unless checked"
+              />
+              <label className="flex items-center gap-2 text-xs text-ink/55">
+                <input name="biomarkers_replace" type="checkbox" value="true" />
+                Replace biomarkers with this list; checked with a blank box simulates clearing them.
+              </label>
+            </label>
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-ink/45">Medications</span>
+              <textarea
+                className="min-h-24 rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                name="medications"
+                placeholder="Optional replacement list; leave blank to preserve unless checked"
+              />
+              <label className="flex items-center gap-2 text-xs text-ink/55">
+                <input name="medications_replace" type="checkbox" value="true" />
+                Replace medications with this active-medication list; checked with a blank box simulates clearing them.
+              </label>
+            </label>
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-ink/45">Therapies</span>
+              <textarea
+                className="min-h-24 rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                name="therapies"
+                placeholder="Optional replacement list; leave blank to preserve unless checked"
+              />
+              <label className="flex items-center gap-2 text-xs text-ink/55">
+                <input name="therapies_replace" type="checkbox" value="true" />
+                Replace therapies with this list; checked with a blank box simulates clearing them.
+              </label>
+            </label>
+            <div className="grid gap-3 rounded-3xl border border-ink/8 bg-sand/45 p-4">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-ink/45">Lab value</span>
+              <input
+                className="rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                name="lab_name"
+                placeholder="Lab name, e.g. ANC"
+              />
+              <div className="grid gap-3 md:grid-cols-2">
+                <input
+                  className="rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                  inputMode="decimal"
+                  name="lab_value"
+                  placeholder="Numeric value"
+                />
+                <input
+                  className="rounded-2xl border border-ink/10 bg-white px-4 py-3 text-ink"
+                  name="lab_unit"
+                  placeholder="Unit"
+                />
+              </div>
+              <label className="flex items-center gap-2 text-xs text-ink/55">
+                <input name="labs_replace" type="checkbox" value="true" />
+                Replace labs with this value; checked with blank fields simulates clearing labs.
+              </label>
+            </div>
+            <button className="rounded-full bg-ink px-5 py-3 text-sm font-semibold text-sand" type="submit">
+              Run what-if scenario
+            </button>
+          </form>
         </Panel>
 
         <Panel title="Recent Match Results" eyebrow="Persisted runs">

--- a/frontend/src/app/patients/[patientId]/simulate/page.tsx
+++ b/frontend/src/app/patients/[patientId]/simulate/page.tsx
@@ -1,0 +1,220 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/page-header";
+import { Panel } from "@/components/panel";
+import { StatusPill } from "@/components/status-pill";
+import { ctmApi } from "@/lib/api/client";
+import { loadSimulationScenario } from "@/lib/simulation-store";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function firstValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function hasVisibleDelta(result: {
+  status_changed: boolean;
+  blockers_removed: string[];
+  blockers_added: string[];
+  missing_data_removed: string[];
+  missing_data_added: string[];
+  clarifiable_blockers_removed: string[];
+  clarifiable_blockers_added: string[];
+  unsupported_removed: string[];
+  unsupported_added: string[];
+  review_required_removed: string[];
+  review_required_added: string[];
+}): boolean {
+  return (
+    result.status_changed ||
+    result.blockers_removed.length > 0 ||
+    result.blockers_added.length > 0 ||
+    result.missing_data_removed.length > 0 ||
+    result.missing_data_added.length > 0 ||
+    result.clarifiable_blockers_removed.length > 0 ||
+    result.clarifiable_blockers_added.length > 0 ||
+    result.unsupported_removed.length > 0 ||
+    result.unsupported_added.length > 0 ||
+    result.review_required_removed.length > 0 ||
+    result.review_required_added.length > 0
+  );
+}
+
+function renderAppliedList(items: { description: string }[] | null | undefined): string {
+  if (items === undefined || items === null) {
+    return "Baseline preserved";
+  }
+  if (items.length === 0) {
+    return "Cleared";
+  }
+  return items.map((item) => item.description).join(", ");
+}
+
+function SummaryCard({ label, value, helper }: { label: string; value: number | string; helper: string }) {
+  return (
+    <div className="rounded-3xl border border-ink/8 bg-sand/55 p-5">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-ink/45">{label}</p>
+      <p className="mt-3 text-3xl font-semibold text-ink">{value}</p>
+      <p className="mt-2 text-sm text-ink/60">{helper}</p>
+    </div>
+  );
+}
+
+export default async function PatientSimulationPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ patientId: string }>;
+  searchParams?: Promise<SearchParams>;
+}) {
+  const { patientId } = await params;
+  const queryParams = (await searchParams) ?? {};
+  const scenarioToken = firstValue(queryParams.scenario);
+  const request = scenarioToken ? await loadSimulationScenario(scenarioToken, patientId) : null;
+  const patient = await ctmApi.getPatient(patientId);
+
+  if (request === null) {
+    return (
+      <>
+        <PageHeader
+          label="What-if Scenario"
+          title={`Simulated match for ${patient.external_id ?? patient.id}`}
+          description="Exploratory eligibility deltas only. This simulation does not update patient facts or persist match results."
+          actions={
+            <Link className="rounded-full bg-ink px-5 py-3 text-sm font-semibold text-sand" href={`/patients/${patient.id}`}>
+              Back to patient
+            </Link>
+          }
+        />
+
+        <Panel title="Scenario unavailable" eyebrow="Expired or invalid token">
+          <p className="text-sm text-ink/70">
+            The saved what-if inputs were not found or have expired. Return to the patient page and run a fresh simulation
+            so results are never shown without the intended scenario patch.
+          </p>
+        </Panel>
+      </>
+    );
+  }
+
+  const simulation = await ctmApi.simulatePatientMatch(patientId, request);
+
+  const changedResults = simulation.results.filter(hasVisibleDelta);
+  const visibleResults = changedResults.length > 0 ? changedResults : simulation.results.slice(0, 10);
+
+  return (
+    <>
+      <PageHeader
+        label="What-if Scenario"
+        title={`Simulated match for ${patient.external_id ?? patient.id}`}
+        description="Exploratory eligibility deltas only. This simulation does not update patient facts or persist match results."
+        actions={
+          <Link className="rounded-full bg-ink px-5 py-3 text-sm font-semibold text-sand" href={`/patients/${patient.id}`}>
+            Back to patient
+          </Link>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-4">
+        <SummaryCard
+          label="Newly eligible"
+          value={simulation.deltas.newly_eligible}
+          helper="Trials that moved to eligible in the scenario."
+        />
+        <SummaryCard
+          label="Newly blocked"
+          value={simulation.deltas.newly_blocked}
+          helper="Trials that became less favorable."
+        />
+        <SummaryCard
+          label="Changed"
+          value={simulation.deltas.status_changed}
+          helper="Results with any status change."
+        />
+        <SummaryCard
+          label="Baseline source"
+          value={simulation.baseline_source}
+          helper="Baseline and scenario are recomputed against the same current corpus."
+        />
+      </div>
+
+      <Panel title="Scenario inputs" eyebrow="Applied patch">
+        <div className="grid gap-3 text-sm text-ink/70 md:grid-cols-2">
+          <p>ECOG: {simulation.applied_changes.ecog_status ?? "Baseline preserved"}</p>
+          <p>Biomarkers: {renderAppliedList(simulation.applied_changes.biomarkers)}</p>
+          <p>Medications: {renderAppliedList(simulation.applied_changes.medications)}</p>
+          <p>Therapies: {renderAppliedList(simulation.applied_changes.therapies)}</p>
+          <p>Labs: {renderAppliedList(simulation.applied_changes.labs)}</p>
+        </div>
+      </Panel>
+
+      <Panel title="Simulation result deltas" eyebrow="Baseline vs simulated">
+        <div className="grid gap-4">
+          {visibleResults.map((result) => (
+            <div key={result.trial_id} className="rounded-3xl border border-ink/8 bg-sand/55 p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <p className="text-sm font-semibold text-ink">{result.trial_brief_title}</p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.22em] text-ink/45">{result.trial_nct_id}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {result.baseline_status ? <StatusPill value={result.baseline_status} /> : null}
+                  <span className="text-ink/40">→</span>
+                  {result.scenario_status ? <StatusPill value={result.scenario_status} /> : null}
+                </div>
+              </div>
+              <div className="mt-4 grid gap-3 text-sm text-ink/68 md:grid-cols-2">
+                <div>
+                  <p className="font-semibold text-ink">Blockers removed</p>
+                  <p>{result.blockers_removed.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Blockers added</p>
+                  <p>{result.blockers_added.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Missing data removed</p>
+                  <p>{result.missing_data_removed.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Missing data added</p>
+                  <p>{result.missing_data_added.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Clarifiable blockers removed</p>
+                  <p>{result.clarifiable_blockers_removed.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Clarifiable blockers added</p>
+                  <p>{result.clarifiable_blockers_added.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Unsupported criteria removed</p>
+                  <p>{result.unsupported_removed.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Unsupported criteria added</p>
+                  <p>{result.unsupported_added.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Review required removed</p>
+                  <p>{result.review_required_removed.join("; ") || "None"}</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-ink">Review required added</p>
+                  <p>{result.review_required_added.join("; ") || "None"}</p>
+                </div>
+              </div>
+              <p className="mt-4 text-sm text-ink/60">{result.scenario_summary_explanation}</p>
+            </div>
+          ))}
+        </div>
+      </Panel>
+    </>
+  );
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -11,6 +11,8 @@ import type {
   MatchResultListResponse,
   MatchReviewQueueResponse,
   MatchRunResponse,
+  MatchSimulationRequest,
+  MatchSimulationResponse,
   PatientCreatePayload,
   PatientDetail,
   PatientListResponse,
@@ -96,6 +98,12 @@ export const ctmApi = {
     apiRequest<PatientDetail>(`/patients/${patientId}`, { method: "PATCH", auth: true, body: payload }),
   matchPatient: (patientId: string) =>
     apiRequest<MatchRunResponse>(`/patients/${patientId}/match`, { method: "POST", auth: true }),
+  simulatePatientMatch: (patientId: string, payload: MatchSimulationRequest) =>
+    apiRequest<MatchSimulationResponse>(`/patients/${patientId}/simulate-match`, {
+      method: "POST",
+      auth: true,
+      body: payload
+    }),
   listPatientMatches: (patientId: string, query = "") =>
     apiRequest<MatchResultListResponse>(`/patients/${patientId}/matches${query}`, { auth: true }),
   getMatch: (matchId: string) => apiRequest<MatchResultDetail>(`/matches/${matchId}`, { auth: true }),

--- a/frontend/src/lib/api/openapi.json
+++ b/frontend/src/lib/api/openapi.json
@@ -2456,6 +2456,392 @@
         "title": "MatchRunResponse",
         "type": "object"
       },
+      "MatchSimulationAppliedChanges": {
+        "additionalProperties": false,
+        "properties": {
+          "biomarkers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PatientBiomarkerInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Biomarkers"
+          },
+          "ecog_status": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ecog Status"
+          },
+          "labs": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PatientLabInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Labs"
+          },
+          "medications": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PatientMedicationInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Medications"
+          },
+          "therapies": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PatientTherapyInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Therapies"
+          }
+        },
+        "title": "MatchSimulationAppliedChanges",
+        "type": "object"
+      },
+      "MatchSimulationRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "biomarkers": {
+            "items": {
+              "$ref": "#/components/schemas/PatientBiomarkerInput"
+            },
+            "title": "Biomarkers",
+            "type": "array"
+          },
+          "ecog_status": {
+            "maximum": 5.0,
+            "minimum": 0.0,
+            "title": "Ecog Status",
+            "type": "integer"
+          },
+          "labs": {
+            "items": {
+              "$ref": "#/components/schemas/PatientLabInput"
+            },
+            "title": "Labs",
+            "type": "array"
+          },
+          "medications": {
+            "items": {
+              "$ref": "#/components/schemas/PatientMedicationInput"
+            },
+            "title": "Medications",
+            "type": "array"
+          },
+          "therapies": {
+            "items": {
+              "$ref": "#/components/schemas/PatientTherapyInput"
+            },
+            "title": "Therapies",
+            "type": "array"
+          }
+        },
+        "title": "MatchSimulationRequest",
+        "type": "object"
+      },
+      "MatchSimulationResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "applied_changes": {
+            "$ref": "#/components/schemas/MatchSimulationAppliedChanges"
+          },
+          "baseline_source": {
+            "enum": [
+              "persisted",
+              "computed"
+            ],
+            "title": "Baseline Source",
+            "type": "string"
+          },
+          "baseline_summary": {
+            "$ref": "#/components/schemas/MatchSimulationSummary"
+          },
+          "deltas": {
+            "$ref": "#/components/schemas/MatchSimulationSummary"
+          },
+          "patient_id": {
+            "format": "uuid",
+            "title": "Patient Id",
+            "type": "string"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/MatchSimulationResultDelta"
+            },
+            "title": "Results",
+            "type": "array"
+          },
+          "scenario_source": {
+            "const": "simulated",
+            "default": "simulated",
+            "title": "Scenario Source",
+            "type": "string"
+          },
+          "scenario_summary": {
+            "$ref": "#/components/schemas/MatchSimulationSummary"
+          }
+        },
+        "required": [
+          "patient_id",
+          "baseline_source",
+          "applied_changes",
+          "baseline_summary",
+          "scenario_summary",
+          "deltas"
+        ],
+        "title": "MatchSimulationResponse",
+        "type": "object"
+      },
+      "MatchSimulationResultDelta": {
+        "additionalProperties": false,
+        "properties": {
+          "baseline_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "eligible",
+                  "possible",
+                  "ineligible"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Baseline Status"
+          },
+          "baseline_summary_explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Baseline Summary Explanation"
+          },
+          "blockers_added": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Blockers Added",
+            "type": "array"
+          },
+          "blockers_removed": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Blockers Removed",
+            "type": "array"
+          },
+          "clarifiable_blockers_added": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Clarifiable Blockers Added",
+            "type": "array"
+          },
+          "clarifiable_blockers_removed": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Clarifiable Blockers Removed",
+            "type": "array"
+          },
+          "missing_data_added": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing Data Added",
+            "type": "array"
+          },
+          "missing_data_removed": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing Data Removed",
+            "type": "array"
+          },
+          "review_required_added": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Review Required Added",
+            "type": "array"
+          },
+          "review_required_removed": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Review Required Removed",
+            "type": "array"
+          },
+          "scenario_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "eligible",
+                  "possible",
+                  "ineligible"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scenario Status"
+          },
+          "scenario_summary_explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scenario Summary Explanation"
+          },
+          "status_changed": {
+            "title": "Status Changed",
+            "type": "boolean"
+          },
+          "trial_brief_title": {
+            "title": "Trial Brief Title",
+            "type": "string"
+          },
+          "trial_id": {
+            "format": "uuid",
+            "title": "Trial Id",
+            "type": "string"
+          },
+          "trial_nct_id": {
+            "title": "Trial Nct Id",
+            "type": "string"
+          },
+          "unsupported_added": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Unsupported Added",
+            "type": "array"
+          },
+          "unsupported_removed": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Unsupported Removed",
+            "type": "array"
+          }
+        },
+        "required": [
+          "trial_id",
+          "trial_nct_id",
+          "trial_brief_title",
+          "status_changed"
+        ],
+        "title": "MatchSimulationResultDelta",
+        "type": "object"
+      },
+      "MatchSimulationSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "eligible": {
+            "title": "Eligible",
+            "type": "integer"
+          },
+          "ineligible": {
+            "title": "Ineligible",
+            "type": "integer"
+          },
+          "newly_blocked": {
+            "default": 0,
+            "title": "Newly Blocked",
+            "type": "integer"
+          },
+          "newly_eligible": {
+            "default": 0,
+            "title": "Newly Eligible",
+            "type": "integer"
+          },
+          "possible": {
+            "title": "Possible",
+            "type": "integer"
+          },
+          "review_required": {
+            "default": 0,
+            "title": "Review Required",
+            "type": "integer"
+          },
+          "source": {
+            "enum": [
+              "persisted",
+              "computed",
+              "simulated"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "status_changed": {
+            "default": 0,
+            "title": "Status Changed",
+            "type": "integer"
+          },
+          "total_trials": {
+            "title": "Total Trials",
+            "type": "integer"
+          },
+          "unchanged": {
+            "default": 0,
+            "title": "Unchanged",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_trials",
+          "eligible",
+          "possible",
+          "ineligible",
+          "source"
+        ],
+        "title": "MatchSimulationSummary",
+        "type": "object"
+      },
       "PatientBiomarkerInput": {
         "additionalProperties": false,
         "properties": {
@@ -5767,6 +6153,111 @@
           }
         ],
         "summary": "List Patient Matches"
+      }
+    },
+    "/api/v1/patients/{patient_id}/simulate-match": {
+      "post": {
+        "operationId": "simulate_patient_match_api_v1_patients__patient_id__simulate_match_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "patient_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Patient Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MatchSimulationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchSimulationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "invalid_api_key",
+                  "detail": "Valid X-API-Key header required",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API key"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "not_found",
+                  "detail": "Trial not found",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Requested resource was not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "validation_error",
+                  "detail": "nct_id: String should match pattern '^NCT\\d{8}$'",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "internal_server_error",
+                  "detail": "Internal server error",
+                  "request_id": "7d3f998a-865f-4adf-a1b9-4cd34a6f70ef"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unhandled server error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "summary": "Simulate Patient Match"
       }
     },
     "/api/v1/pipeline/coverage": {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -466,6 +466,95 @@ export type MatchResultListResponse = {
   per_page: number;
 };
 
+
+export type PatientBiomarkerInput = {
+  description: string;
+  value_text?: string | null;
+  coded_concepts?: CodedConcept[];
+};
+
+export type PatientLabInput = {
+  description: string;
+  value_numeric?: number | null;
+  value_text?: string | null;
+  unit?: string | null;
+  coded_concepts?: CodedConcept[];
+};
+
+export type PatientTherapyInput = {
+  description: string;
+  line_of_therapy?: number | null;
+  completed?: boolean | null;
+  coded_concepts?: CodedConcept[];
+};
+
+export type PatientMedicationInput = {
+  description: string;
+  active?: boolean;
+  coded_concepts?: CodedConcept[];
+};
+
+export type MatchSimulationRequest = {
+  ecog_status?: number;
+  biomarkers?: PatientBiomarkerInput[];
+  therapies?: PatientTherapyInput[];
+  medications?: PatientMedicationInput[];
+  labs?: PatientLabInput[];
+};
+
+export type MatchSimulationAppliedChanges = {
+  ecog_status?: number | null;
+  biomarkers?: PatientBiomarkerInput[] | null;
+  therapies?: PatientTherapyInput[] | null;
+  medications?: PatientMedicationInput[] | null;
+  labs?: PatientLabInput[] | null;
+};
+
+export type MatchSimulationSummary = {
+  total_trials: number;
+  eligible: number;
+  possible: number;
+  ineligible: number;
+  newly_eligible: number;
+  newly_blocked: number;
+  status_changed: number;
+  unchanged: number;
+  review_required: number;
+  source: "persisted" | "computed" | "simulated";
+};
+
+export type MatchSimulationResultDelta = {
+  trial_id: string;
+  trial_nct_id: string;
+  trial_brief_title: string;
+  baseline_status?: "eligible" | "possible" | "ineligible" | null;
+  scenario_status?: "eligible" | "possible" | "ineligible" | null;
+  status_changed: boolean;
+  blockers_removed: string[];
+  blockers_added: string[];
+  missing_data_removed: string[];
+  missing_data_added: string[];
+  clarifiable_blockers_removed: string[];
+  clarifiable_blockers_added: string[];
+  unsupported_removed: string[];
+  unsupported_added: string[];
+  review_required_removed: string[];
+  review_required_added: string[];
+  baseline_summary_explanation?: string | null;
+  scenario_summary_explanation?: string | null;
+};
+
+export type MatchSimulationResponse = {
+  patient_id: string;
+  scenario_source: "simulated";
+  baseline_source: "persisted" | "computed";
+  applied_changes: MatchSimulationAppliedChanges;
+  baseline_summary: MatchSimulationSummary;
+  scenario_summary: MatchSimulationSummary;
+  deltas: MatchSimulationSummary;
+  results: MatchSimulationResultDelta[];
+};
+
 export type HealthResponse = {
   status: "healthy" | "degraded";
   pipeline_version: string;

--- a/frontend/src/lib/simulation-store.ts
+++ b/frontend/src/lib/simulation-store.ts
@@ -1,0 +1,100 @@
+import "server-only";
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "crypto";
+import { cookies } from "next/headers";
+
+import type { MatchSimulationRequest } from "@/lib/api/types";
+
+const TTL_SECONDS = 30 * 60;
+const TTL_MS = TTL_SECONDS * 1000;
+const COOKIE_PREFIX = "ctm_match_sim_";
+const MAX_COOKIE_VALUE_BYTES = 3500;
+const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEVELOPMENT_SECRET = "ctm-match-simulation-development-only-secret";
+
+type StoredSimulationScenario = {
+  token: string;
+  patientId: string;
+  payload: MatchSimulationRequest;
+  expiresAt: number;
+};
+
+function cookieName(patientId: string): string {
+  return `${COOKIE_PREFIX}${patientId}`;
+}
+
+function encryptionKey(): Buffer {
+  const configuredSecret = process.env.MATCH_SIMULATION_COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET;
+  if (!configuredSecret && process.env.NODE_ENV === "production") {
+    throw new Error("MATCH_SIMULATION_COOKIE_SECRET or NEXTAUTH_SECRET must be configured in production.");
+  }
+
+  return createHash("sha256")
+    .update(configuredSecret ?? DEVELOPMENT_SECRET)
+    .digest();
+}
+
+function sealScenario(stored: StoredSimulationScenario): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(stored), "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ciphertext]).toString("base64url");
+}
+
+function unsealScenario(value: string): StoredSimulationScenario | null {
+  try {
+    const sealed = Buffer.from(value, "base64url");
+    const iv = sealed.subarray(0, 12);
+    const tag = sealed.subarray(12, 28);
+    const ciphertext = sealed.subarray(28);
+    const decipher = createDecipheriv("aes-256-gcm", encryptionKey(), iv);
+    decipher.setAuthTag(tag);
+    const raw = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+    return JSON.parse(raw) as StoredSimulationScenario;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSimulationScenario(patientId: string, payload: MatchSimulationRequest): Promise<string> {
+  const token = randomUUID();
+  const stored: StoredSimulationScenario = {
+    token,
+    patientId,
+    payload,
+    expiresAt: Date.now() + TTL_MS
+  };
+  const sealed = sealScenario(stored);
+  if (Buffer.byteLength(sealed, "utf8") > MAX_COOKIE_VALUE_BYTES) {
+    throw new Error("Simulation scenario is too large. Shorten the replacement lists and try again.");
+  }
+  const cookieStore = await cookies();
+  cookieStore.set(cookieName(patientId), sealed, {
+    httpOnly: true,
+    maxAge: TTL_SECONDS,
+    path: `/patients/${patientId}/simulate`,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production"
+  });
+  return token;
+}
+
+export async function loadSimulationScenario(token: string, patientId: string): Promise<MatchSimulationRequest | null> {
+  if (!TOKEN_PATTERN.test(token)) {
+    return null;
+  }
+
+  const cookieStore = await cookies();
+  const stored = unsealScenario(cookieStore.get(cookieName(patientId))?.value ?? "");
+  if (
+    !stored ||
+    stored.token !== token ||
+    stored.patientId !== patientId ||
+    typeof stored.expiresAt !== "number" ||
+    stored.expiresAt < Date.now()
+  ) {
+    return null;
+  }
+  return stored.payload ?? {};
+}

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -75,6 +75,7 @@ class TestRouteRegistration:
             assert "/api/v1/patients" in paths
             assert "/api/v1/patients/{patient_id}" in paths
             assert "/api/v1/patients/{patient_id}/match" in paths
+            assert "/api/v1/patients/{patient_id}/simulate-match" in paths
             assert "/api/v1/patients/{patient_id}/matches" in paths
             assert "/api/v1/matches/{match_id}" in paths
 
@@ -869,6 +870,48 @@ class TestGetCriteria:
         assert data["criteria"][0]["category"] == "line_of_therapy"
         assert "pipeline_run_id" in data["criteria"][0]
         assert "raw_expression" in data["criteria"][0]
+
+
+@pytestmark_docker
+class TestPatientMatchSimulation:
+    def test_simulate_match_changes_outcome_without_persisting_match_run(self, client, db_session):
+        trial, _, _, _ = _seed_trial(db_session)
+        _add_completed_run(
+            db_session,
+            trial,
+            [
+                {
+                    "type": "inclusion",
+                    "category": "performance_status",
+                    "original_text": "ECOG performance status must be 0 to 1",
+                    "operator": "lte",
+                    "value_low": 1,
+                }
+            ],
+        )
+        patient = Patient(
+            external_id=f"simulation-patient-{uuid.uuid4().hex[:8]}",
+            birth_date=date(1980, 1, 1),
+            ecog_status=2,
+        )
+        db_session.add(patient)
+        db_session.commit()
+        baseline_run_count = db_session.query(MatchRun).count()
+
+        response = client.post(f"/api/v1/patients/{patient.id}/simulate-match", json={"ecog_status": 1})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["patient_id"] == str(patient.id)
+        assert data["scenario_source"] == "simulated"
+        assert data["baseline_source"] == "computed"
+        assert data["deltas"]["newly_eligible"] >= 1
+        target_delta = next(item for item in data["results"] if item["trial_id"] == str(trial.id))
+        assert target_delta["baseline_status"] == "ineligible"
+        assert target_delta["scenario_status"] == "eligible"
+        assert target_delta["status_changed"] is True
+        assert db_session.get(Patient, patient.id).ecog_status == 2
+        assert db_session.query(MatchRun).count() == baseline_run_count
 
 
 @pytestmark_docker

--- a/tests/unit/test_match_simulation.py
+++ b/tests/unit/test_match_simulation.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+from uuid import NAMESPACE_DNS, uuid5
+
+import pytest
+
+from app.api.schemas import MatchSimulationRequest, PatientBiomarkerInput, PatientMedicationInput, PatientTherapyInput
+from app.matching.simulation import build_result_delta, build_simulated_patient, summarize_simulation_results
+from app.models.database import Patient, PatientBiomarker, PatientMedication, PatientTherapy
+
+
+def test_match_simulation_request_accepts_bounded_patient_fact_patch():
+    payload = MatchSimulationRequest.model_validate(
+        {
+            "ecog_status": 1,
+            "biomarkers": [{"description": "EGFR exon 19 deletion", "value_text": "positive"}],
+            "medications": [{"description": "prednisone", "active": False}],
+            "therapies": [{"description": "platinum chemotherapy", "line_of_therapy": 1, "completed": True}],
+        }
+    )
+
+    assert payload.ecog_status == 1
+    assert payload.biomarkers[0].description == "EGFR exon 19 deletion"
+    assert payload.medications[0].active is False
+    assert payload.therapies[0].line_of_therapy == 1
+
+
+def test_match_simulation_request_rejects_out_of_range_ecog_status():
+    with pytest.raises(Exception, match="ecog_status"):
+        MatchSimulationRequest.model_validate({"ecog_status": 9})
+
+
+def test_match_simulation_request_rejects_explicit_null_fields():
+    with pytest.raises(Exception, match="Omit fields to preserve baseline"):
+        MatchSimulationRequest.model_validate({"ecog_status": None})
+
+    with pytest.raises(Exception, match="Omit fields to preserve baseline"):
+        MatchSimulationRequest.model_validate({"biomarkers": None})
+
+
+def test_build_simulated_patient_overlays_patch_without_mutating_baseline():
+    patient = Patient(id="00000000-0000-0000-0000-000000000001", ecog_status=2)
+    patient.biomarkers = [PatientBiomarker(description="EGFR wild type", value_text="negative")]
+    patient.medications = [PatientMedication(description="prednisone", active=True)]
+    patient.therapies = [PatientTherapy(description="radiation", completed=True)]
+
+    simulated = build_simulated_patient(
+        patient,
+        MatchSimulationRequest(
+            ecog_status=1,
+            biomarkers=[PatientBiomarkerInput(description="EGFR exon 19 deletion", value_text="positive")],
+            medications=[PatientMedicationInput(description="prednisone", active=False)],
+            therapies=[PatientTherapyInput(description="platinum chemotherapy", line_of_therapy=1, completed=True)],
+        ),
+    )
+
+    assert simulated is not patient
+    assert simulated.id == patient.id
+    assert simulated.ecog_status == 1
+    assert [item.description for item in simulated.biomarkers] == ["EGFR exon 19 deletion"]
+    assert simulated.medications[0].active is False
+    assert [item.description for item in simulated.therapies] == ["platinum chemotherapy"]
+    assert patient.ecog_status == 2
+    assert [item.description for item in patient.biomarkers] == ["EGFR wild type"]
+    assert patient.medications[0].active is True
+
+
+def _result(trial_id, status, blockers=None, review_required_count=0, clarifiable=None, unsupported=None):
+    trial_uuid = uuid5(NAMESPACE_DNS, f"simulation-trial-{trial_id}")
+    return SimpleNamespace(
+        trial=SimpleNamespace(id=trial_uuid, nct_id=f"NCT{trial_id}", brief_title=f"Trial {trial_id}"),
+        trial_id=trial_uuid,
+        overall_status=status,
+        state="structured_safe",
+        state_reason=None,
+        score=1.0 if status == "eligible" else 0.0,
+        favorable_count=1 if status == "eligible" else 0,
+        unfavorable_count=1 if status == "ineligible" else 0,
+        unknown_count=1 if status == "possible" else 0,
+        requires_review_count=review_required_count,
+        summary_explanation=f"{status} summary",
+        gap_report_payload={
+            "hard_blockers": [
+                {"criterion_text": blocker, "category": "performance_status", "summary": blocker}
+                for blocker in (blockers or [])
+            ],
+            "missing_data": [],
+            "review_required": [],
+            "clarifiable_blockers": [
+                {"criterion_text": item, "category": "other", "summary": item} for item in (clarifiable or [])
+            ],
+            "unsupported": [
+                {"criterion_text": item, "category": "other", "summary": item} for item in (unsupported or [])
+            ],
+        },
+    )
+
+
+def test_build_result_delta_classifies_status_and_blocker_changes():
+    baseline = _result("1", "possible", blockers=["ECOG must be 0 to 1"])
+    scenario = _result("1", "eligible")
+
+    delta = build_result_delta(baseline, scenario)
+
+    assert delta.status_changed is True
+    assert delta.baseline_status == "possible"
+    assert delta.scenario_status == "eligible"
+    assert delta.blockers_removed == ["ECOG must be 0 to 1"]
+    assert delta.blockers_added == []
+
+
+def test_summarize_simulation_results_counts_newly_eligible_blocked_and_unchanged():
+    summary = summarize_simulation_results(
+        [
+            _result("1", "possible"),
+            _result("2", "eligible"),
+            _result("3", "possible"),
+        ],
+        [
+            _result("1", "eligible"),
+            _result("2", "ineligible", blockers=["New blocker"]),
+            _result("3", "possible"),
+        ],
+    )
+
+    assert summary.newly_eligible == 1
+    assert summary.newly_blocked == 1
+    assert summary.status_changed == 2
+    assert summary.unchanged == 1
+
+
+def test_build_result_delta_includes_uncertainty_bucket_changes():
+    baseline = _result("4", "possible", clarifiable=["Clarify steroid dose"], unsupported=["Unsupported washout rule"])
+    scenario = _result("4", "possible", clarifiable=["Clarify lab timing"], unsupported=[])
+
+    delta = build_result_delta(baseline, scenario)
+
+    assert delta.status_changed is False
+    assert delta.clarifiable_blockers_removed == ["Clarify steroid dose"]
+    assert delta.clarifiable_blockers_added == ["Clarify lab timing"]
+    assert delta.unsupported_removed == ["Unsupported washout rule"]
+    assert delta.unsupported_added == []


### PR DESCRIPTION
## Summary
- Add a read-only `POST /api/v1/patients/{patient_id}/simulate-match` endpoint for transient patient fact patches.
- Compare computed baseline and simulated scenario against the same current corpus without mutating patient data or persisting match runs.
- Add frontend what-if flow with explicit preserve/replace/clear semantics, opaque scenario token redirect, encrypted short-lived scenario cookie storage, and visible validation/unavailable states.
- Surface aggregate and per-trial deltas, including uncertainty bucket changes.

Closes #12

## Verification
- `PYTHONPATH=. ./.ctm-dev/bin/python frontend/scripts/export_openapi.py`
- `PY_FILES=$( (git diff --name-only -- '*.py'; git ls-files --others --exclude-standard -- '*.py') | sort -u ); [ -z "$PY_FILES" ] || ./.ctm-dev/bin/ruff check $PY_FILES`
- `./.ctm-dev/bin/pytest -q` — 407 passed
- `cd frontend && npm run typecheck && npm run build`
