### PR TITLE
fix: prioritize prior_therapy classification and add anti-PD-1 synonym support

### DIFF
--- a/app/extraction/constants.py
+++ b/app/extraction/constants.py
@@ -1,6 +1,10 @@
 """Shared terminology constants used by extraction-adjacent modules."""
 
 PD_1_THERAPY_SYNONYMS = (
+    "anti-pd-1 therapy",
+    "anti pd 1 therapy",
+    "anti-pd-1 inhibitor therapy",
+    "anti pd 1 inhibitor therapy",
     "pd-1 therapy",
     "pd 1 therapy",
     "pd-1 inhibitor therapy",

--- a/app/extraction/criteria_classifier.py
+++ b/app/extraction/criteria_classifier.py
@@ -17,6 +17,7 @@ _MOLECULAR_PATTERN = re.compile(
 )
 _PRIOR_THERAPY_TEXT_PATTERN = re.compile(
     r"\b(?:prior\s+treatment|prior\s+therapy|chemotherap(?:y|ies)|radiation(?:\s+therapy)?|immunotherap(?:y|ies)|"
+    r"checkpoint\s+inhibitor\s+therapy|anti[-\s]+pd[-\s]*1(?:\s+inhibitor)?\s+therapy|"
     r"endocrine\s+therapy|hormonal\s+therapy|targeted\s+therap(?:y|ies)|systemic\s+therapy|"
     r"biologic(?:al)?\s+therapy)\b",
     re.I,
@@ -855,7 +856,9 @@ class RuleBasedClassifier:
                     return normalized
 
         therapy_match = re.search(
-            r"\b(?:pd-1(?:/pd-l1)?(?:\s+inhibitor)?\s+therapy|pd-l1\s+therapy|"
+            r"\b(?:anti[-\s]+pd[-\s]*1(?:\s+inhibitor)?\s+therapy|"
+            r"pd-1(?:/pd-l1)?(?:\s+inhibitor)?\s+therapy|pd-l1\s+therapy|"
+            r"checkpoint\s+inhibitor\s+therapy|immunotherap(?:y|ies)|"
             r"platinum-based chemotherapy|chemotherapy|kras-targeted therapy|agent targeting kras)\b",
             text,
             re.I,

--- a/app/extraction/criteria_classifier.py
+++ b/app/extraction/criteria_classifier.py
@@ -580,6 +580,10 @@ class RuleBasedClassifier:
             return "disease_status"
         if _CURRENT_CONDITION_PATTERN.search(text):
             return "diagnosis"
+        if _LINE_PATTERN.search(text):
+            return "line_of_therapy"
+        if _PRIOR_THERAPY_TEXT_PATTERN.search(text):
+            return "prior_therapy"
         if _STAGE_PATTERN.search(text):
             return "disease_stage"
         if _HISTOLOGY_PATTERN.search(text):
@@ -592,10 +596,6 @@ class RuleBasedClassifier:
             return "molecular_alteration"
         if _CONCOMITANT_PATTERN.search(text) or _CYP_RESTRICTION_PATTERN.search(text):
             return "concomitant_medication"
-        if _LINE_PATTERN.search(text):
-            return "line_of_therapy"
-        if _PRIOR_THERAPY_TEXT_PATTERN.search(text):
-            return "prior_therapy"
         if _ORGAN_FUNCTION_PATTERN.search(text):
             return "organ_function"
         return "other"
@@ -623,6 +623,8 @@ class RuleBasedClassifier:
                 or _CYP_RESTRICTION_PATTERN.search(text)
             ):
                 return category, "partial", 0.3, True, "complex_criteria"
+            return category, "parsed", 0.6, False, None
+        if category in {"prior_therapy", "line_of_therapy"}:
             return category, "parsed", 0.6, False, None
         if category == "organ_function" and not _ORGAN_FUNCTION_COMPLEXITY_PATTERN.search(text):
             return category, "parsed", 0.6, False, None

--- a/tests/unit/test_criteria_classifier.py
+++ b/tests/unit/test_criteria_classifier.py
@@ -154,6 +154,21 @@ class TestCategoryAssignment:
         )
         assert result.category == "prior_therapy"
 
+    @pytest.mark.parametrize(
+        ("text", "expected_value_text"),
+        [
+            ("Prior anti-PD-1 therapy for metastatic disease", "anti-pd-1 therapy"),
+            ("Prior checkpoint inhibitor therapy for metastatic disease", "checkpoint inhibitor therapy"),
+            ("Prior immunotherapy for metastatic disease", "immunotherapy"),
+        ],
+    )
+    def test_therapy_class_parent_phrasing_stays_prior_therapy(self, classifier, text, expected_value_text):
+        result = classifier.classify(text, [])
+        assert result.category == "prior_therapy"
+        assert result.parse_status == "parsed"
+        assert result.review_required is False
+        assert result.value_text == expected_value_text
+
     def test_disease_with_stage_modifier_stays_diagnosis_primary(self, classifier):
         result = classifier.classify(
             "Has histologically confirmed diagnosis of metastatic non-small cell lung cancer",

--- a/tests/unit/test_criterion_projection.py
+++ b/tests/unit/test_criterion_projection.py
@@ -146,6 +146,30 @@ def test_safe_pd_1_therapy_class_projects_to_medication_statement():
     )
 
 
+def test_safe_anti_pd_1_therapy_class_projects_to_medication_statement():
+    mapper = CriterionProjectionMapper()
+    criterion = _make_criterion(
+        category="prior_therapy",
+        type="inclusion",
+        original_text="Prior anti-PD-1 therapy for metastatic disease",
+        value_text="anti-PD-1 therapy",
+        entities=[Entity(text="anti-PD-1 therapy", label="DRUG", start=6, end=22)],
+        allowance_text=None,
+    )
+
+    projections = mapper.project_criterion(criterion)
+
+    assert len(projections) == 1
+    assert projections[0].projection_status == "projected"
+    assert projections[0].terminology_status == "nci_thesaurus_grounded"
+    assert projections[0].review_required is False
+    assert projections[0].code == "C178320"
+    assert projections[0].resource_type == "MedicationStatement"
+    assert projections[0].resource["medicationCodeableConcept"]["coding"][0]["system"] == (
+        "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl"
+    )
+
+
 def test_named_drug_wrapper_projects_via_embedded_rxnorm_drug():
     mapper = CriterionProjectionMapper()
     criterion = _make_criterion(
@@ -233,6 +257,28 @@ def test_cyp3a4_inducer_inhibitor_class_remains_blocked_pending_safe_source():
     assert projections[0].normalized_term == "cyp3a4 inhibitors inducers"
     assert projections[0].projection_status == "blocked_missing_class_code"
     assert projections[0].terminology_status == "recognized_class_missing_safe_code"
+    assert projections[0].review_required is True
+    assert projections[0].resource is None
+
+
+@pytest.mark.parametrize("mention_text", ["checkpoint inhibitor therapy", "immunotherapy"])
+def test_broad_therapy_class_parent_phrasing_remains_review_required_for_safety(mention_text: str):
+    mapper = CriterionProjectionMapper()
+    criterion = _make_criterion(
+        category="prior_therapy",
+        type="inclusion",
+        original_text=f"Prior {mention_text} for metastatic disease",
+        value_text=mention_text,
+        entities=[Entity(text=mention_text, label="DRUG", start=6, end=6 + len(mention_text))],
+        allowance_text=None,
+    )
+
+    projections = mapper.project_criterion(criterion)
+
+    assert len(projections) == 1
+    assert projections[0].normalized_term == mention_text
+    assert projections[0].projection_status == "review_required_ambiguous_class"
+    assert projections[0].terminology_status == "ambiguous_class_no_safe_code"
     assert projections[0].review_required is True
     assert projections[0].resource is None
 


### PR DESCRIPTION
## Summary

Fixes a classification precedence bug where disease_stage matched before prior_therapy and line_of_therapy, causing text-only prior-therapy criteria to be misclassified when stage keywords were also present.

Adds anti-PD-1 synonym variants and expands prior-therapy regex patterns. Broad class phrases remain review_required at projection time by design.

## Commits
1. fix: prioritize prior_therapy and line_of_therapy over disease_stage in classifier
2. feat: add anti-PD-1 therapy synonyms and expand prior therapy regex patterns
3. test: cover therapy-class parent phrasing and anti-PD-1 projection

## Test Plan
- [x] 64 unit tests pass
- [x] 224 integration tests pass
- [x] Ruff lint clean

Refs: OMA-11

Closes #10